### PR TITLE
moved $$props.class to surface in Alert & Simple

### DIFF
--- a/components/mdc/Dialog/Alert.svelte
+++ b/components/mdc/Dialog/Alert.svelte
@@ -43,9 +43,9 @@ onMount(() => {
 })
 </script>
 
-<div class="mdc-dialog {$$props.class}" bind:this={element}>
+<div class="mdc-dialog" bind:this={element}>
   <div class="mdc-dialog__container">
-    <div class="mdc-dialog__surface"
+    <div class="mdc-dialog__surface {$$props.class}"
          role="alertdialog"
          aria-modal="true"
          aria-labelledby="title"

--- a/components/mdc/Dialog/Simple.svelte
+++ b/components/mdc/Dialog/Simple.svelte
@@ -35,9 +35,9 @@ const toAction = json => JSON.stringify(json)
 const fromAction = s => JSON.parse(s)
 </script>
 
-<div class="mdc-dialog {$$props.class}" bind:this={element}>
+<div class="mdc-dialog" bind:this={element}>
   <div class="mdc-dialog__container">
-    <div class="mdc-dialog__surface" role="alertdialog" aria-modal="true" aria-labelledby="dialog-title" aria-describedby="dialog-content">
+    <div class="mdc-dialog__surface {$$props.class}" role="alertdialog" aria-modal="true" aria-labelledby="dialog-title" aria-describedby="dialog-content">
       <!--(notes from docs) Title cannot contain leading whitespace due to mdc-typography-baseline-top() -->
       <h2 class="mdc-dialog__title" id="dialog-title">{title}</h2>
       


### PR DESCRIPTION
This allows the padding class to apply inside the dialog box while margin applies outside.