### PR TITLE
Sass deployment fix

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -24,11 +24,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
+      - run: npm install -g sass
       - run: npm ci
       - run: npm test
 
       - name: Build
-        run: sass components/global.scss components/global.css; npm run build
+        run: npm run build
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo test",
     "dev": "sass components/global.scss components/global.css; start-storybook -p 6007",
-    "build": "build-storybook"
+    "build": "sass components/global.scss components/global.css; build-storybook"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Trying to compile global.css during the github action deployment so can avoid maintaining it manually.

- added `run: npm install -g sass` to gh-pages.yml
- moved `sass components/global.scss components/global.css;` command to build script