### PR TITLE
Change and add global classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - $$props.class to Badge, Form, CustomCard, Tour and StaticChip so they can accept global classes
 - Badge, CustomCard, Form, StaticChip and Tour stories to Storybook
-- global.scss to generate full range of padding and margin from 1rem to 8rem, height and width from 0 to 100% in increments of 10, z-index from 0 to 10.
+- global.scss to generate full range of padding and margin from 1rem to 8rem, height and width from 0 to 100% in increments of 5, z-index from 0 to 10.
 - align-item and align-self flex utilites to global.scss
 - .text-align-start, .text-align-end, .d-inline, .d-block, .relative, .fixed and .fs-10 added to global.scss
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### BREAKING CHANGES
 - .align-center, .align-left and .align-right global classes are now .text-align-center, .text-align-left and .text-align-right.
 - .aligned global class is now .align-items-center
+- Progress.Linear prop barColorProvided default value is now false
+- TopAppBar prop bgColorIsVariant default value is now false
 
 ### Added
 - $$props.class to Badge, Form, CustomCard, Tour and StaticChip so they can accept global classes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - global.css is compiled during Storybook dev and deployment build from global.scss and used only for Storybook
 - _index.scss uses global.scss
 
+### BREAKING CHANGES
+- .align-center, .align-left and .align-right global classes are now .text-align-center, .text-align-left and .text-align-right.
+- .aligned global class is now .align-items-center
+
 ### Added
 - $$props.class to Badge, Form, CustomCard, Tour and StaticChip so they can accept global classes
 - Badge, CustomCard, Form, StaticChip and Tour stories to Storybook
-- global.scss to generate full range of padding and margin from 1rem to 8rem
+- global.scss to generate full range of padding and margin from 1rem to 8rem, height and width from 0 to 100% in increments of 10, z-index from 0 to 10.
+- align-item and align-self flex utilites to global.scss
+- .text-align-start, .text-align-end, .d-inline, .d-block, .relative and .fixed added to global.scss
 
 ### Removed
 - global.css was removed and added to .gitignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Badge, CustomCard, Form, StaticChip and Tour stories to Storybook
 - global.scss to generate full range of padding and margin from 1rem to 8rem, height and width from 0 to 100% in increments of 10, z-index from 0 to 10.
 - align-item and align-self flex utilites to global.scss
-- .text-align-start, .text-align-end, .d-inline, .d-block, .relative and .fixed added to global.scss
+- .text-align-start, .text-align-end, .d-inline, .d-block, .relative, .fixed and .fs-10 added to global.scss
 
 ### Removed
 - global.css was removed and added to .gitignore

--- a/components/Badge.svelte
+++ b/components/Badge.svelte
@@ -14,4 +14,4 @@
   }
 </style>
 
-<span class="dib align-center white fs-16 br-50 background {$$props.class}" style="--theme-color: {color}" ><slot /></span>
+<span class="dib text-align-center white fs-16 br-50 background {$$props.class}" style="--theme-color: {color}" ><slot /></span>

--- a/components/CustomCard.svelte
+++ b/components/CustomCard.svelte
@@ -30,7 +30,7 @@
         <img class="w-100" {src} {alt} class:disabled/>
     </div>
 
-    <div class="flex justify-between aligned black">
+    <div class="flex justify-between align-items-center black">
         <h4>{title}</h4>
 
         <span class="material-icons">{icon}</span>  

--- a/components/StaticChip.svelte
+++ b/components/StaticChip.svelte
@@ -10,8 +10,8 @@
   }
 </style>
 
-<div class="chip black flex justify-center aligned mb-1 mr-2 fs-14 br-16px {$$props.class}">
-  <div class="chip-content flex aligned">
+<div class="chip black flex justify-center align-items-center mb-1 mr-2 fs-14 br-16px {$$props.class}">
+  <div class="chip-content flex align-items-center">
     <slot></slot>
   </div>  
 </div>

--- a/components/global.scss
+++ b/components/global.scss
@@ -103,8 +103,16 @@ $i: 0;
 }
 
 // display
-.dib{
+.dib {
   display: inline-block;
+}
+
+.d-inline {
+	display: inline;
+}
+
+.d-block {
+	display: block;
 }
 
 // text

--- a/components/global.scss
+++ b/components/global.scss
@@ -67,7 +67,7 @@ $sides: (top: t, right: r, bottom: b, left: l);
   }
 }
 
-//position
+// position
 .relative {
 	position: relative;
 }
@@ -88,14 +88,21 @@ $sides: (top: t, right: r, bottom: b, left: l);
   top: 50%;
 }
 
-.z-10 {
-	z-index: 10;
-}
-
 .stick-b{
 	position:fixed;
 	bottom:0px;
 }
+
+// z-index z-0 to z-10
+$i: 0;
+
+@for $i from 0 through 10 {
+	.z-#{$i} {
+		z-index: #{$i};
+	}
+}
+
+// display
 
 .dib{
   display: inline-block;

--- a/components/global.scss
+++ b/components/global.scss
@@ -57,9 +57,9 @@ $sides: (top: t, right: r, bottom: b, left: l);
 }
 
 // margin & padding sides m(side)-(1 to 8), p(side)-(1 to 8)
-@for $i from $start through $end {
+@each $property, $prop in $properties {
   @each $side, $name in $sides {
-    @each $property, $prop in $properties {
+    @for $i from $start through $end {
       .#{$prop}#{$name}-#{$i} {
         #{$property}-#{$side}: #{$i}rem;
       }

--- a/components/global.scss
+++ b/components/global.scss
@@ -67,6 +67,15 @@ $sides: (top: t, right: r, bottom: b, left: l);
   }
 }
 
+//position
+.relative {
+	position: relative;
+}
+
+.fixed {
+	position: fixed;
+}
+
 .absolute {
 	position: absolute;
 }

--- a/components/global.scss
+++ b/components/global.scss
@@ -116,23 +116,23 @@ $i: 0;
 }
 
 // text
-.align-start {
+.text-align-start {
 	text-align: start;
 }
 
-.align-end {
+.text-align-end {
 	text-align: end;
 }
 
-.align-right {
+.text-align-right {
   text-align: right;
 }
 
-.align-left {
+.text-align-left {
   text-align: left;
 }
 
-.align-center {
+.text-align-center {
 	text-align: center;
 }
 

--- a/components/global.scss
+++ b/components/global.scss
@@ -116,6 +116,14 @@ $i: 0;
 }
 
 // text
+.align-start {
+	text-align: start;
+}
+
+.align-end {
+	text-align: end;
+}
+
 .align-right {
   text-align: right;
 }

--- a/components/global.scss
+++ b/components/global.scss
@@ -238,8 +238,40 @@ $i: 0;
 	justify-content: flex-start;
 }
 
-.aligned {
+.align-items-center {
 	align-items: center;
+}
+
+.align-items-end {
+	align-items: flex-end;
+}
+
+.align-items-strech {
+	align-items: stretch;
+}
+
+.align-items-baseline {
+	align-items: baseline;
+}
+
+.align-self-auto {
+	align-self: auto;
+}
+
+.align-self-center {
+	align-self: center;
+}
+
+.align-self-end {
+	align-self: flex-end;
+}
+
+.align-self-strech {
+	align-self: stretch;
+}
+
+.align-self-baseline {
+	align-self: baseline;
 }
 
 // misc

--- a/components/global.scss
+++ b/components/global.scss
@@ -1,18 +1,23 @@
 /*************/
 /* Utilities */
 /*************/
-.h-100 {
-	height: 100%;
-}
 
-.w-100 {
-	width: 100%;
-}
-.w-50 {
-	width: 50%;
-}
-.w-40 {
-	width: 40%;
+// height and width h-0 through h-100, w-0 through w-100
+$dim-start:  0 !default;
+$dim-end:   100 !default;
+$interval:    5 !default;
+$dimensions: (height: h, width: w);
+
+@each $dimension, $dim in $dimensions {
+	$i: $dim-start;
+	
+	@while $i <= $dim-end {
+		.#{$dim}-#{$i} {
+			#{$dimension}: #{$i}#{'%'};
+				
+			$i: $i + $interval;
+		}
+	}
 }
 
 // margin and padding
@@ -31,7 +36,7 @@ $sides: (top: t, right: r, bottom: b, left: l);
   }
 }
 
-// margin & padding X (m or p)X-1 through (m or p)X-8
+// margin & padding x (m or p)x-1 through (m or p)x-8
 @each $property, $prop in $properties {
 	@for $i from $start through $end {
 		.#{$prop}x-#{$i} {
@@ -41,7 +46,7 @@ $sides: (top: t, right: r, bottom: b, left: l);
 	}
 }
 
-// margin & padding Y (m or p)Y-1 through (m or p)Y-8
+// margin & padding y (m or p)y-1 through (m or p)y-8
 @each $property, $prop in $properties {
 	@for $i from $start through $end {
 		.#{$prop}y-#{$i} {

--- a/components/global.scss
+++ b/components/global.scss
@@ -140,6 +140,10 @@ $i: 0;
 	direction: rtl;
 }
 
+.fs-10 {
+	font-size: 10px;
+}
+
 .fs-12 {
 	font-size: 12px;
 }

--- a/components/global.scss
+++ b/components/global.scss
@@ -103,11 +103,11 @@ $i: 0;
 }
 
 // display
-
 .dib{
   display: inline-block;
 }
 
+// text
 .align-right {
   text-align: right;
 }
@@ -150,10 +150,6 @@ $i: 0;
 
 .uppercase {
 	text-transform: uppercase;
-}
-
-.pointer {
-	cursor: pointer;
 }
 
 /* text color */
@@ -228,4 +224,9 @@ $i: 0;
 
 .aligned {
 	align-items: center;
+}
+
+// misc
+.pointer {
+	cursor: pointer;
 }

--- a/components/mdc/Datatable/DataRowItem.svelte
+++ b/components/mdc/Datatable/DataRowItem.svelte
@@ -3,4 +3,4 @@ export let numeric = false
 export let colspan = 1
 </script>
   
-<td class="mdc-data-table__cell align-left" class:mdc-data-table__cell--numeric={numeric} {colspan}><slot /></td>
+<td class="mdc-data-table__cell text-align-left" class:mdc-data-table__cell--numeric={numeric} {colspan}><slot /></td>

--- a/components/mdc/Progress/Linear.svelte
+++ b/components/mdc/Progress/Linear.svelte
@@ -5,7 +5,7 @@ import { onMount } from 'svelte'
 
 export let indeterminate = false
 export let value = 0
-export let barColorProvided = true
+export let barColorProvided = false
 
 let element = {}
 let mdcProgress

--- a/components/mdc/TopAppBar/TopAppBar.svelte
+++ b/components/mdc/TopAppBar/TopAppBar.svelte
@@ -5,7 +5,7 @@ import { MDCTopAppBar } from '@material/top-app-bar'
 import { createEventDispatcher, onMount } from 'svelte'
 import title from './title'
 
-export let bgColorIsVariant = true
+export let bgColorIsVariant = false
 export let dense = false
 export let fixed = false
 export let navIconBreakpointClass = ''

--- a/components/page/Page.svelte
+++ b/components/page/Page.svelte
@@ -22,7 +22,7 @@ div.mdc-layout-grid {
 <div class="mdc-layout-grid">
   <div class="mdc-layout-grid__inner">
     {#if layout == 'default'}
-      <div class={center ? `${cell12} flex column aligned` : `${cell12}`}>
+      <div class={center ? `${cell12} flex column align-items-center` : `${cell12}`}>
         {#if loading && !noProgress}
           <Progress.Circular class="absolute r-50 t-50 z-10" />
         {/if}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silintl/ui-components",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Reusable Svelte components for some internal applications",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION

![Screen Shot 2021-06-02 at 12 10 16 PM](https://user-images.githubusercontent.com/70765247/120514703-93166e00-c39b-11eb-87c6-de5d810b5f05.png)
### BREAKING CHANGES
- .align-center, .align-left and .align-right global classes are now .text-align-center, .text-align-left and .text-align-right.
- .aligned global class is now .align-items-center
- Progress.Linear prop barColorProvided default value is now false
- TopAppBar prop bgColorIsVariant default value is now false

### Added
- global.scss generates height and width from 0 to 100% in increments of 10, z-index from 0 to 10.
- align-item and align-self flex utilites to global.scss
- .text-align-start, .text-align-end, .d-inline, .d-block, .relative, .fixed and .fs-10 added to global.scss

### Changed
- version to 2.0.0
- updated changelog