### PR TITLE
Progress.Linear bar-color improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### BREAKING CHANGES
 - .align-center, .align-left and .align-right global classes are now .text-align-center, .text-align-left and .text-align-right.
 - .aligned global class is now .align-items-center
-- Progress.Linear prop barColorProvided default value is now false
+- Progress.Linear barColorProvided prop deleted
+- Progress.Linear uses --progress-bar-color and falls back to --mdc-theme-primary instead of --sil-primary-blue from the apps _theme file
 - TopAppBar prop bgColorIsVariant default value is now false
 
 ### Added
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - global.css was removed and added to .gitignore
+- Progress.Linear prop barColorProvided
 
 ### Fixed
 - Tour was failing to replace key with value of data prop in steps content.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - .align-center, .align-left and .align-right global classes are now .text-align-center, .text-align-left and .text-align-right.
 - .aligned global class is now .align-items-center
 - Progress.Linear barColorProvided prop deleted
-- Progress.Linear uses --progress-bar-color and falls back to --mdc-theme-primary instead of --sil-primary-blue from the apps _theme file
+- Progress.Linear uses --progress-bar-color instead of --sil-primary-blue from the apps _theme file and falls back to --mdc-theme-primary
 - TopAppBar prop bgColorIsVariant default value is now false
 
 ### Added
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - global.css was removed and added to .gitignore
-- Progress.Linear prop barColorProvided
+- barColorProvided from Progress.Linear
 
 ### Fixed
 - Tour was failing to replace key with value of data prop in steps content.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ List (twoLine, avatar) [
 ]
 
 Progress [
-	Progress.Circular, Progress.Linear (indeterminate, value, barColorProvided)
+	Progress.Circular, Progress.Linear (indeterminate, value)
 ]
 
 Select (options, width, disabled, selectedID)

--- a/components/mdc/Progress/Linear.svelte
+++ b/components/mdc/Progress/Linear.svelte
@@ -5,7 +5,6 @@ import { onMount } from 'svelte'
 
 export let indeterminate = false
 export let value = 0
-export let barColorProvided = false
 
 let element = {}
 let mdcProgress
@@ -25,10 +24,10 @@ onMount(() => {
     <div class="mdc-linear-progress__buffer-bar"></div>
     <div class="mdc-linear-progress__buffer-dots"></div>
   </div>
-  <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar" class:bar-color={barColorProvided}>
+  <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar bar-color">
     <span class="mdc-linear-progress__bar-inner"></span>
   </div>
-  <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar">
+  <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar bar-color">
     <span class="mdc-linear-progress__bar-inner"></span>
   </div>
 </div>

--- a/components/mdc/Progress/_index.scss
+++ b/components/mdc/Progress/_index.scss
@@ -4,5 +4,5 @@
 @include linear-progress.core-styles;
 
 .bar-color {    
-  @include linear-progress.bar-color(var(--sil-primary-blue)); //TODO change variable name to something more generic, fallback to primary theme color?
+  @include linear-progress.bar-color(var(--progress-bar-color, var(--mdc-theme-primary)));
 }


### PR DESCRIPTION
- deleted barColorProvided from Progress.Linear and README
- Progress.Linear uses --progress-bar-color instead of --sil-primary-blue from the apps _theme file and falls back to --mdc-theme-primary using googles default theme if none provided
- updated CHANGELOG