### PR TITLE
Release 2.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@storybook/svelte": "^6.3.2",
         "css-loader": "^5.2.6",
         "material-components-web": "^10.0.0",
-        "sass": "^1.35.1",
+        "sass": "^1.32.12",
         "sass-loader": "^11.0.1",
         "style-loader": "^2.0.0",
         "svelte": "^3.x",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@storybook/svelte": "^6.3.2",
     "css-loader": "^5.2.6",
     "material-components-web": "^10.0.0",
-    "sass": "^1.35.1",
+    "sass": "^1.32.12",
     "sass-loader": "^11.0.1",
     "style-loader": "^2.0.0",
     "svelte": "^3.x",


### PR DESCRIPTION
Reverted sass to 1.32.12 due to [excessive warning](https://github.com/twbs/bootstrap/issues/34051)
sass deprecated the use of / for division which is used in Material and Bootstrap