### PR TITLE
Dispatch `Select` 'populated' event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Dispatch 'populated' event when a Select's options are populated. Useful for
+  knowing when it's safe to set the initial selectedID value.
 
 ## [3.0.0](https://github.com/silinternational/ui-components/releases/tag/v3.0.0) - 2021-08-13
 ### Added

--- a/components/mdc/Select/Select.svelte
+++ b/components/mdc/Select/Select.svelte
@@ -37,6 +37,15 @@ afterUpdate(() => {
   // As a reactive statement, this would execute before the DOM is updated with the new options list.
   // This makes sure the index is updated AFTER the select list contains the full list of options.
   mdcSelect.selectedIndex = selectedIndex
+  
+  // If options have been provided, give the current processes time to finish
+  // what they're doing, then indicate that this Select is now populated with
+  // options. At this point, it's safe for the selectedID to be initialized.
+  if (options.length > 0) {
+    setTimeout(() => {
+      dispatch('populated')
+    })
+  }
 })
 </script>
 


### PR DESCRIPTION
### Added
- Dispatch 'populated' event when a Select's options are populated. Useful for knowing when it's safe to set the initial `selectedID` value.

---

Ideally, I'd like some solution that keeps _all_ of this messiness inside the `Select` component, but I haven't found one yet. This approach seems to enable us to reliably set the `selectedID` property without the MDCSelect throwing an error like the following:
```
Uncaught (in promise) TypeError: this.getValue() is undefined
```