### PR TITLE
feat(Menu): add support for actions in menuItems

### DIFF
--- a/components/mdc/Menu/Menu.svelte
+++ b/components/mdc/Menu/Menu.svelte
@@ -22,12 +22,14 @@ onMount(() => {
 })
 
 const isMenuItemActive = (currentUrl, menuItemUrl) => currentUrl === menuItemUrl
-const handleItemClick = (url) => {
+const handleItemClick = (url, action) => {
   if (url) {
     $goto(url)
+  } else if (typeof action === 'function') {
+    action()
   }
 }
-const handleItemKeydown = (e, url) => (e.code == 'Space' || e.code == 'Enter') && handleItemClick(url)
+const handleItemKeydown = (e, url, action) => (e.code == 'Space' || e.code == 'Enter') && handleItemClick(url, action)
 const closeMenuHandler = () => {
   if (!menu.open) {
     //checks to make sure the click wasn't opening the menu or on the menu
@@ -41,11 +43,11 @@ const closeMenuHandler = () => {
 
 <div class="mdc-menu mdc-menu-surface {$$props.class}" bind:this={element}>
   <ul class="mdc-list" role="menu" aria-hidden="true" aria-orientation="vertical" tabindex="-1">
-    {#each menuItems as { icon, label, url }, i}
+    {#each menuItems as { icon, label, url, action }, i}
       <!-- svelte-ignore a11y-invalid-attribute -->
       <li
-        on:click|preventDefault={() => handleItemClick(url)}
-        on:keydown|preventDefault={(e) => handleItemKeydown(e, url)}
+        on:click|preventDefault={() => handleItemClick(url, action)}
+        on:keydown|preventDefault={(e) => handleItemKeydown(e, url, action)}
         role="menuitem"
         class="mdc-list-item"
         class:mdc-list-item--activated={isMenuItemActive(currentUrl, url)}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@silintl/ui-components",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "MIT",
       "devDependencies": {
         "@roxi/routify": "^2.x",
@@ -22726,6 +22726,11 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
       },
       "engines": {
         "node": ">=0.10.0"

--- a/stories/Menu.stories.svelte
+++ b/stories/Menu.stories.svelte
@@ -9,6 +9,11 @@ const args = {
   menuOpen: true,
   menuItems: [
     {
+      icon: 'notifications',
+      label: 'Alerts',
+      action: () => alert('Hello!'),
+    },
+    {
       icon: 'settings',
       label: 'User settings',
       url: '/household/settings',


### PR DESCRIPTION
This allows you to specify an action instead of a url for a menu item. When clicked, the provided function will execute instead of redirecting you to the provided url