### PR TITLE
Add counter to TextInput,  TextInput and TextArea outlines red when reaching limit and add utils, add MoneyInput

### DIFF
--- a/components/global.scss
+++ b/components/global.scss
@@ -139,9 +139,9 @@ $sides: (
 
 // UNITS: PIXELS!!
 $startPX: 0 !default;
-$endPX: 25 !default;
+$endPX: 50 !default;
 
-// margin & padding m-0px through m-25px, p-0px through p-25px
+// margin & padding m-0px through m-50px, p-0px through p-50px
 @each $property, $prop in $properties {
   @for $i from $startPX through $endPX {
     .#{$prop}-#{$i}px {
@@ -150,7 +150,7 @@ $endPX: 25 !default;
   }
 }
 
-// margin & padding x (m or p)x-0px through (m or p)x-25px
+// margin & padding x (m or p)x-0px through (m or p)x-50px
 @each $property, $prop in $properties {
   @for $i from $startPX through $endPX {
     .#{$prop}x-#{$i}px {
@@ -160,7 +160,7 @@ $endPX: 25 !default;
   }
 }
 
-// margin & padding y (m or p)y-0px through (m or p)y-25px
+// margin & padding y (m or p)y-0px through (m or p)y-50px
 @each $property, $prop in $properties {
   @for $i from $startPX through $endPX {
     .#{$prop}y-#{$i}px {
@@ -170,7 +170,7 @@ $endPX: 25 !default;
   }
 }
 
-// margin & padding sides m(side)-(0 to 25)px, p(side)-(0 to 25)px
+// margin & padding sides m(side)-(0 to 50)px, p(side)-(0 to 50)px
 @each $property, $prop in $properties {
   @each $side, $name in $sides {
     @for $i from $startPX through $endPX {

--- a/components/global.scss
+++ b/components/global.scss
@@ -2,10 +2,30 @@
 /* Utilities */
 /*************/
 
-// height and width h-0 through h-100, w-0 through w-100
+// height and width
+.h-auto {
+  height: auto !important;
+}
+.h-fit-content {
+  height: fit-content !important;
+}
+.max-content-height {
+  height: max-content !important;
+}
+.w-auto {
+  width: auto !important;
+}
+.w-fit-content {
+  width: fit-content !important;
+}
+.max-content-width {
+  width: max-content !important;
+}
+
+//h-0 through h-100, w-0 through w-100
 $dim-start: 0 !default;
 $dim-end: 100 !default;
-$interval: 5 !default;
+$interval: 1 !default;
 $dimensions: (
   height: h,
   width: w,
@@ -23,9 +43,47 @@ $dimensions: (
   }
 }
 
+//min-height and min-width
+@each $dimension, $dim in $dimensions {
+  $i: $dim-start;
+
+  @while $i <= $dim-end {
+    .min-#{$dim}-#{$i} {
+      min-#{$dimension}: #{$i}#{'%'} !important;
+
+      $i: $i + $interval;
+    }
+  }
+}
+
+//max-height and max-width
+@each $dimension, $dim in $dimensions {
+  $i: $dim-start;
+
+  @while $i <= $dim-end {
+    .max-#{$dim}-#{$i} {
+      max-#{$dimension}: #{$i}#{'%'} !important;
+
+      $i: $i + $interval;
+    }
+  }
+}
 // margin and padding
+.m-auto {
+  margin: auto !important;
+}
+.m-0-auto {
+  margin: 0 auto !important;
+}
+.p-0-auto {
+  padding: 0 auto !important;
+}
+.p-auto {
+  padding: auto !important;
+}
+
 $start: 0 !default;
-$end: 8 !default;
+$end: 10 !default;
 
 $properties: (
   margin: m,
@@ -39,7 +97,7 @@ $sides: (
 );
 
 // UNITS: REM !!
-// margin & padding m-0 through m-8, p-0 through p-8
+// margin & padding m-0 through m-10, p-0 through p-10
 @each $property, $prop in $properties {
   @for $i from $start through $end {
     .#{$prop}-#{$i} {
@@ -48,7 +106,7 @@ $sides: (
   }
 }
 
-// margin & padding x (m or p)x-0 through (m or p)x-8
+// margin & padding x (m or p)x-0 through (m or p)x-10
 @each $property, $prop in $properties {
   @for $i from $start through $end {
     .#{$prop}x-#{$i} {
@@ -58,7 +116,7 @@ $sides: (
   }
 }
 
-// margin & padding y (m or p)y-0 through (m or p)y-8
+// margin & padding y (m or p)y-0 through (m or p)y-10
 @each $property, $prop in $properties {
   @for $i from $start through $end {
     .#{$prop}y-#{$i} {
@@ -68,7 +126,7 @@ $sides: (
   }
 }
 
-// margin & padding sides m(side)-(0 to 8), p(side)-(0 to 8)
+// margin & padding sides m(side)-(0 to 10), p(side)-(0 to 10)
 @each $property, $prop in $properties {
   @each $side, $name in $sides {
     @for $i from $start through $end {

--- a/components/mdc/TextInput/MoneyInput.svelte
+++ b/components/mdc/TextInput/MoneyInput.svelte
@@ -18,6 +18,11 @@ let element = {}
 let mdcTextField = {}
 
 $: mdcTextField.value = value
+$: width = `${element.offsetWidth}px`
+$: valueLength = value.toString().length
+$: hasReachedMaxLength = maxlength && valueLength >= maxlength
+$: error = hasReachedMaxLength
+$: showCounter = maxlength && valueLength / maxlength > 0.85
 
 onMount(() => {
   mdcTextField = new MDCTextField(element)
@@ -46,12 +51,17 @@ const focus = (node) => autofocus && node.focus()
 .mdc-text-field--label-floating .mdc-floating-label {
   margin-left: 0;
 }
+.mdc-text-field-helper-line {
+  float: right;
+  padding-right: 1rem;
+}
 </style>
 
 <label
   class="mdc-text-field mdc-text-field--outlined {$$props.class} textfield-radius"
   class:mdc-text-field--no-label={!label}
   class:mdc-text-field--disabled={disabled}
+  class:mdc-text-field--invalid={hasReachedMaxLength}
   bind:this={element}
 >
   <i class="material-icons" aria-hidden="true">attach_money</i>
@@ -72,11 +82,16 @@ const focus = (node) => autofocus && node.focus()
     {disabled}
     {placeholder}
   />
+  {#if hasReachedMaxLength}
+    <span class="mdc-text-field__affix mdc-text-field__affix--suffix"
+      ><i class="material-icons error" aria-hidden="true">error</i></span
+    >
+  {/if}
   <span class="mdc-notched-outline">
     <span class="mdc-notched-outline__leading" />
     {#if label}
       <span class="mdc-notched-outline__notch">
-        <span class="mdc-floating-label label-margin" id={labelID}>
+        <span class="mdc-floating-label label-margin" class:error id={labelID}>
           {label}
         </span>
       </span>
@@ -84,6 +99,15 @@ const focus = (node) => autofocus && node.focus()
     <span class="mdc-notched-outline__trailing" />
   </span>
 </label>
-{#if required && !value}
-  <div class="required">*Required</div>
-{/if}
+<div style="width: {width};">
+  {#if required && !value}
+    <div class="required">*Required</div>
+  {/if}
+  {#if showCounter}
+    <div class="mdc-text-field-helper-line">
+      <div class="mdc-text-field-character-counter" class:error>
+        {valueLength} / {maxlength}
+      </div>
+    </div>
+  {/if}
+</div>

--- a/components/mdc/TextInput/MoneyInput.svelte
+++ b/components/mdc/TextInput/MoneyInput.svelte
@@ -1,0 +1,89 @@
+<!-- https://github.com/material-components/material-components-web/tree/master/packages/mdc-textfield -->
+<script>
+import { MDCTextField } from '@material/textfield'
+import { generateRandomID } from '../../../random'
+import { onMount } from 'svelte'
+
+export let label = ''
+export let value = ''
+export let placeholder = ''
+export let maxlength = undefined
+export let autofocus = false
+export let disabled = false
+export let required = false
+
+const labelID = generateRandomID('text-label-')
+
+let element = {}
+let mdcTextField = {}
+
+$: mdcTextField.value = value
+
+onMount(() => {
+  mdcTextField = new MDCTextField(element)
+  return () => mdcTextField.destroy()
+})
+
+const focus = (node) => autofocus && node.focus()
+</script>
+
+<style>
+.material-icons {
+  color: rgb(133, 140, 148);
+  position: relative;
+  top: 0.4rem;
+  right: 0.6rem;
+}
+.required {
+  color: var(--mdc-required-input, var(--mdc-theme-status-error));
+  font-size: small;
+  margin-left: 1rem;
+  margin-top: 0.2rem;
+}
+.label-margin {
+  margin-left: 1.1rem;
+}
+.mdc-text-field--label-floating .mdc-floating-label {
+  margin-left: 0;
+}
+</style>
+
+<label
+  class="mdc-text-field mdc-text-field--outlined {$$props.class} textfield-radius"
+  class:mdc-text-field--no-label={!label}
+  class:mdc-text-field--disabled={disabled}
+  bind:this={element}
+>
+  <i class="material-icons" aria-hidden="true">attach_money</i>
+  <input
+    step="0.01"
+    type="number"
+    min="0"
+    class="mdc-text-field__input"
+    aria-labelledby={labelID}
+    bind:value
+    use:focus
+    on:blur
+    on:keydown
+    on:keypress
+    on:keyup
+    {required}
+    {maxlength}
+    {disabled}
+    {placeholder}
+  />
+  <span class="mdc-notched-outline">
+    <span class="mdc-notched-outline__leading" />
+    {#if label}
+      <span class="mdc-notched-outline__notch">
+        <span class="mdc-floating-label label-margin" id={labelID}>
+          {label}
+        </span>
+      </span>
+    {/if}
+    <span class="mdc-notched-outline__trailing" />
+  </span>
+</label>
+{#if required && !value}
+  <div class="required">*Required</div>
+{/if}

--- a/components/mdc/TextInput/TextArea.svelte
+++ b/components/mdc/TextInput/TextArea.svelte
@@ -19,6 +19,7 @@ let textarea = {}
 let height = ''
 
 $: hasReachedMaxLength = maxlength && value.length >= maxlength
+$: error = hasReachedMaxLength
 
 onMount(() => {
   resize()
@@ -52,6 +53,9 @@ const focus = async (node) => {
 label {
   width: 100%;
 }
+.error {
+  color: var(--mdc-theme-status-error, var(--mdc-theme-error)) !important;
+}
 </style>
 
 <label
@@ -79,14 +83,14 @@ label {
     on:blur
   />
   {#if maxlength}
-    <span class="mdc-text-field-character-counter">0 / {maxlength}</span>
+    <span class="mdc-text-field-character-counter" class:error>0 / {maxlength}</span>
   {/if}
   <span class="mdc-notched-outline">
     <span class="mdc-notched-outline__leading" />
 
     {#if label}
       <span class="mdc-notched-outline__notch">
-        <span class="mdc-floating-label" id={labelID}>
+        <span class="mdc-floating-label" class:error id={labelID}>
           {label}
         </span>
       </span>

--- a/components/mdc/TextInput/TextArea.svelte
+++ b/components/mdc/TextInput/TextArea.svelte
@@ -53,9 +53,6 @@ const focus = async (node) => {
 label {
   width: 100%;
 }
-.error {
-  color: var(--mdc-theme-status-error, var(--mdc-theme-error)) !important;
-}
 </style>
 
 <label

--- a/components/mdc/TextInput/TextArea.svelte
+++ b/components/mdc/TextInput/TextArea.svelte
@@ -18,6 +18,8 @@ let element = {}
 let textarea = {}
 let height = ''
 
+$: hasReachedMaxLength = maxlength && value.length >= maxlength
+
 onMount(() => {
   resize()
 
@@ -57,6 +59,7 @@ label {
   class:mdc-text-field--no-label={!label}
   class:mdc-text-field--label-floating={label}
   class:mdc-text-field--with-internal-counter={maxlength}
+  class:mdc-text-field--invalid={hasReachedMaxLength}
   bind:this={element}
 >
   <textarea

--- a/components/mdc/TextInput/TextField.svelte
+++ b/components/mdc/TextInput/TextField.svelte
@@ -11,6 +11,7 @@ export let maxlength = undefined
 export let autofocus = false
 export let disabled = false
 export let required = false
+export let icon = ''
 
 const labelID = generateRandomID('text-label-')
 
@@ -28,11 +29,23 @@ const focus = (node) => autofocus && node.focus()
 </script>
 
 <style>
+.material-icons {
+  color: rgb(133, 140, 148);
+  position: relative;
+  top: 0.4rem;
+  right: 0.6rem;
+}
 .required {
   color: var(--mdc-required-input, var(--mdc-theme-status-error));
   font-size: small;
   margin-left: 1rem;
   margin-top: 0.2rem;
+}
+.label-margin {
+  margin-left: 1.1rem;
+}
+.mdc-text-field--label-floating .mdc-floating-label {
+  margin-left: 0;
 }
 </style>
 
@@ -42,6 +55,7 @@ const focus = (node) => autofocus && node.focus()
   class:mdc-text-field--disabled={disabled}
   bind:this={element}
 >
+  <i class="material-icons" aria-hidden="true">{icon}</i>
   <input
     type="text"
     class="mdc-text-field__input"
@@ -61,7 +75,7 @@ const focus = (node) => autofocus && node.focus()
     <span class="mdc-notched-outline__leading" />
     {#if label}
       <span class="mdc-notched-outline__notch">
-        <span class="mdc-floating-label" id={labelID}>
+        <span class="mdc-floating-label" class:label-margin={icon} id={labelID}>
           {label}
         </span>
       </span>

--- a/components/mdc/TextInput/TextField.svelte
+++ b/components/mdc/TextInput/TextField.svelte
@@ -2,7 +2,7 @@
 <script>
 import { MDCTextField } from '@material/textfield'
 import { generateRandomID } from '../../../random'
-import { onMount } from 'svelte'
+import { afterUpdate, onMount } from 'svelte'
 
 export let label = ''
 export let value = ''
@@ -17,9 +17,9 @@ const labelID = generateRandomID('text-label-')
 
 let element = {}
 let mdcTextField = {}
+let width = ''
 
 $: mdcTextField.value = value
-$: width = `${element.offsetWidth}px`
 $: hasReachedMaxLength = maxlength && value.length >= maxlength
 $: error = hasReachedMaxLength
 $: showCounter = maxlength && value.length / maxlength > 0.85
@@ -28,6 +28,8 @@ onMount(() => {
   mdcTextField = new MDCTextField(element)
   return () => mdcTextField.destroy()
 })
+
+afterUpdate(() => (width = `${element.offsetWidth}px`))
 
 const focus = (node) => autofocus && node.focus()
 </script>
@@ -41,19 +43,12 @@ const focus = (node) => autofocus && node.focus()
 }
 .required {
   color: var(--mdc-required-input, var(--mdc-theme-status-error));
-  font-size: small;
-  margin-left: 1rem;
-  margin-top: 0.2rem;
 }
 .label-margin {
   margin-left: 1.1rem;
 }
 .mdc-text-field--label-floating .mdc-floating-label {
   margin-left: 0;
-}
-.mdc-text-field-helper-line {
-  float: right;
-  padding-right: 1rem;
 }
 </style>
 
@@ -69,6 +64,8 @@ const focus = (node) => autofocus && node.focus()
     type="text"
     class="mdc-text-field__input"
     aria-labelledby={labelID}
+    aria-controls="{labelID}-helper-id"
+    aria-describedby="{labelID}-helper-id"
     bind:value
     use:focus
     on:blur
@@ -98,15 +95,18 @@ const focus = (node) => autofocus && node.focus()
     <span class="mdc-notched-outline__trailing" />
   </span>
 </label>
-<div style="width: {width};">
-  {#if required && !value}
-    <div class="required d-inline">*Required</div>
-  {/if}
+<div class="mdc-text-field-helper-line" style="width: {width};">
+  <div class="mdc-text-field-helper-text" id="{labelID}-helper-id" aria-hidden="true">
+    {#if required && !value}
+      <span class="required">*Required</span>
+    {/if}
+    {#if showCounter}
+      <span class="error">Maximum {maxlength} characters</span>
+    {/if}
+  </div>
   {#if showCounter}
-    <div class="mdc-text-field-helper-line">
-      <div class="mdc-text-field-character-counter" class:error>
-        {value.length} / {maxlength}
-      </div>
+    <div class="mdc-text-field-character-counter" class:error>
+      {value.length} / {maxlength}
     </div>
   {/if}
 </div>

--- a/components/mdc/TextInput/TextField.svelte
+++ b/components/mdc/TextInput/TextField.svelte
@@ -19,6 +19,7 @@ let element = {}
 let mdcTextField = {}
 
 $: mdcTextField.value = value
+$: width = `${element.offsetWidth}px`
 
 onMount(() => {
   mdcTextField = new MDCTextField(element)
@@ -46,6 +47,10 @@ const focus = (node) => autofocus && node.focus()
 }
 .mdc-text-field--label-floating .mdc-floating-label {
   margin-left: 0;
+}
+.mdc-text-field-helper-line {
+  float: right;
+  padding-right: 1rem;
 }
 </style>
 
@@ -83,6 +88,13 @@ const focus = (node) => autofocus && node.focus()
     <span class="mdc-notched-outline__trailing" />
   </span>
 </label>
-{#if required && !value}
-  <div class="required">*Required</div>
-{/if}
+<div style="width: {width};">
+  {#if required && !value}
+    <div class="required d-inline">*Required</div>
+  {/if}
+  {#if maxlength}
+    <div class="mdc-text-field-helper-line">
+      <div class="mdc-text-field-character-counter">0 / {maxlength}</div>
+    </div>
+  {/if}
+</div>

--- a/components/mdc/TextInput/TextField.svelte
+++ b/components/mdc/TextInput/TextField.svelte
@@ -55,9 +55,6 @@ const focus = (node) => autofocus && node.focus()
   float: right;
   padding-right: 1rem;
 }
-.error {
-  color: var(--mdc-theme-status-error, var(--mdc-theme-error));
-}
 </style>
 
 <label
@@ -83,6 +80,12 @@ const focus = (node) => autofocus && node.focus()
     {disabled}
     {placeholder}
   />
+  {#if hasReachedMaxLength}
+    <span class="mdc-text-field__affix mdc-text-field__affix--suffix"
+      ><i class="material-icons error" aria-hidden="true">error</i></span
+    >
+  {/if}
+
   <span class="mdc-notched-outline">
     <span class="mdc-notched-outline__leading" />
     {#if label}

--- a/components/mdc/TextInput/TextField.svelte
+++ b/components/mdc/TextInput/TextField.svelte
@@ -21,6 +21,8 @@ let mdcTextField = {}
 $: mdcTextField.value = value
 $: width = `${element.offsetWidth}px`
 $: hasReachedMaxLength = maxlength && value.length >= maxlength
+$: error = hasReachedMaxLength
+$: showCounter = maxlength && value.length / maxlength > 0.85
 
 onMount(() => {
   mdcTextField = new MDCTextField(element)
@@ -53,6 +55,9 @@ const focus = (node) => autofocus && node.focus()
   float: right;
   padding-right: 1rem;
 }
+.error {
+  color: var(--mdc-theme-status-error, var(--mdc-theme-error));
+}
 </style>
 
 <label
@@ -82,7 +87,7 @@ const focus = (node) => autofocus && node.focus()
     <span class="mdc-notched-outline__leading" />
     {#if label}
       <span class="mdc-notched-outline__notch">
-        <span class="mdc-floating-label" class:label-margin={icon} id={labelID}>
+        <span class="mdc-floating-label" class:label-margin={icon} class:error id={labelID}>
           {label}
         </span>
       </span>
@@ -94,9 +99,11 @@ const focus = (node) => autofocus && node.focus()
   {#if required && !value}
     <div class="required d-inline">*Required</div>
   {/if}
-  {#if maxlength}
+  {#if showCounter}
     <div class="mdc-text-field-helper-line">
-      <div class="mdc-text-field-character-counter">{value.length} / {maxlength}</div>
+      <div class="mdc-text-field-character-counter" class:error>
+        {value.length} / {maxlength}
+      </div>
     </div>
   {/if}
 </div>

--- a/components/mdc/TextInput/TextField.svelte
+++ b/components/mdc/TextInput/TextField.svelte
@@ -20,6 +20,7 @@ let mdcTextField = {}
 
 $: mdcTextField.value = value
 $: width = `${element.offsetWidth}px`
+$: hasReachedMaxLength = maxlength && value.length >= maxlength
 
 onMount(() => {
   mdcTextField = new MDCTextField(element)
@@ -58,6 +59,7 @@ const focus = (node) => autofocus && node.focus()
   class="mdc-text-field mdc-text-field--outlined {$$props.class} textfield-radius"
   class:mdc-text-field--no-label={!label}
   class:mdc-text-field--disabled={disabled}
+  class:mdc-text-field--invalid={hasReachedMaxLength}
   bind:this={element}
 >
   <i class="material-icons" aria-hidden="true">{icon}</i>
@@ -94,7 +96,7 @@ const focus = (node) => autofocus && node.focus()
   {/if}
   {#if maxlength}
     <div class="mdc-text-field-helper-line">
-      <div class="mdc-text-field-character-counter">0 / {maxlength}</div>
+      <div class="mdc-text-field-character-counter">{value.length} / {maxlength}</div>
     </div>
   {/if}
 </div>

--- a/components/mdc/TextInput/_index.scss
+++ b/components/mdc/TextInput/_index.scss
@@ -15,3 +15,6 @@
 .textfield-radius {
   @include textfield.outline-shape-radius(8px);
 }
+.error {
+  color: var(--mdc-theme-status-error, var(--mdc-theme-error)) !important;
+}

--- a/components/mdc/TextInput/index.js
+++ b/components/mdc/TextInput/index.js
@@ -1,5 +1,6 @@
 import './_index.scss'
 import TextArea from './TextArea.svelte'
 import TextField from './TextField.svelte'
+import MoneyInput from './MoneyInput.svelte'
 
-export { TextArea, TextField }
+export { TextArea, TextField, MoneyInput }

--- a/components/mdc/index.js
+++ b/components/mdc/index.js
@@ -21,7 +21,7 @@ import Progress from './Progress'
 import Select from './Select'
 import Snackbar from './Snackbar'
 import TabBar from './TabBar'
-import { TextArea, TextField } from './TextInput'
+import { TextArea, TextField, MoneyInput } from './TextInput'
 import Tooltip from './Tooltip'
 import TopAppBar from './TopAppBar'
 import { setNotice } from './Snackbar/notice'
@@ -40,6 +40,7 @@ export {
   isAboveTablet,
   List,
   Menu,
+  MoneyInput,
   Progress,
   TabBar,
   TextArea,

--- a/stories/MoneyInput.stories.svelte
+++ b/stories/MoneyInput.stories.svelte
@@ -1,0 +1,40 @@
+<script>
+import { Meta, Template, Story } from '@storybook/addon-svelte-csf'
+import { MoneyInput } from '../components/mdc'
+import { copyAndModifyArgs } from './helpers.js'
+
+let title = 'MoneyInput'
+
+const args = {
+  label: title,
+  'on:keydown': (event) => console.log('keydown', event),
+  'on:keypress': (event) => (lastKey = event.key),
+  'on:keyup': (event) => console.log('keyup', event),
+  class: '', //will only work with global class
+}
+
+let lastKey = ''
+</script>
+
+<Meta title="Atoms/MoneyInput" component={MoneyInput} />
+
+<Template let:args>
+  <MoneyInput {...args} on:keydown={args['on:keydown']} on:keypress={args['on:keypress']} on:keyup={args['on:keyup']} />
+  {#if lastKey}
+    <p>Last key pressed: {lastKey}</p>
+  {/if}
+</Template>
+
+<Story name="Default" {args} />
+
+<Story name="Required" args={copyAndModifyArgs(args, { required: true })} />
+
+<Story name="Placeholder" args={copyAndModifyArgs(args, { placeholder: 'Placeholder' })} />
+
+<Story name="Label" args={copyAndModifyArgs(args, { label: 'label' })} />
+
+<Story name="Autofocus" args={copyAndModifyArgs(args, { autofocus: true })} />
+
+<Story name="Disabled" args={copyAndModifyArgs(args, { disabled: true })} />
+
+<Story name="maxlength" args={copyAndModifyArgs(args, { maxlength: 255 })} />

--- a/stories/TextArea.stories.svelte
+++ b/stories/TextArea.stories.svelte
@@ -20,6 +20,14 @@ const args = {
 
 <Story name="Default" {args} />
 
-<Story name="Placeholder" args={copyAndModifyArgs(args, { placeholder: 'Enter text here' })} />
+<Story name="Placeholder" args={copyAndModifyArgs(args, { placeholder: 'placeholder' })} />
+
+<Story name="Label" args={copyAndModifyArgs(args, { label: 'label' })} />
+
+<Story name="Maxlength" args={copyAndModifyArgs(args, { maxlength: 2048 })} />
+
+<Story name="rtl" args={copyAndModifyArgs(args, { rtl: true })} />
+
+<Story name="rows" args={copyAndModifyArgs(args, { rows: 2 })} />
 
 <Story name="Autofocus" args={copyAndModifyArgs(args, { autofocus: true })} />

--- a/stories/TextField.stories.svelte
+++ b/stories/TextField.stories.svelte
@@ -3,10 +3,7 @@ import { Meta, Template, Story } from '@storybook/addon-svelte-csf'
 import { TextField } from '../components/mdc'
 import { copyAndModifyArgs } from './helpers.js'
 
-let title = 'TextField'
-
 const args = {
-  label: title,
   'on:keydown': (event) => console.log('TextField keydown', event),
   'on:keypress': (event) => (lastKey = event.key),
   'on:keyup': (event) => console.log('TextField keyup', event),
@@ -27,7 +24,7 @@ let lastKey = ''
 
 <Story name="Default" {args} />
 
-<Story name="Required" args={copyAndModifyArgs(args, { required: true })} />
+<Story name="label" args={copyAndModifyArgs(args, { label: 'label' })} />
 
 <Story name="Placeholder" args={copyAndModifyArgs(args, { placeholder: 'Enter text here' })} />
 
@@ -38,3 +35,5 @@ let lastKey = ''
 <Story name="maxlength" args={copyAndModifyArgs(args, { maxlength: 50 })} />
 
 <Story name="icon" args={copyAndModifyArgs(args, { icon: 'home' })} />
+
+<Story name="Required" args={copyAndModifyArgs(args, { required: true })} />

--- a/stories/TextField.stories.svelte
+++ b/stories/TextField.stories.svelte
@@ -34,3 +34,7 @@ let lastKey = ''
 <Story name="Autofocus" args={copyAndModifyArgs(args, { autofocus: true })} />
 
 <Story name="Disabled" args={copyAndModifyArgs(args, { disabled: true })} />
+
+<Story name="maxlength" args={copyAndModifyArgs(args, { maxlength: 50 })} />
+
+<Story name="icon" args={copyAndModifyArgs(args, { icon: 'home' })} />


### PR DESCRIPTION
#Add
- min, max, height and width utilities
- margin and padding up to 50px in utilities
- TextField: icon prop and character counter and maxlength warning
- MoneyInput and story
- Prepend TextField and MoneyInput with error icon on maxlength reached

#Change
- TextField, TextArea, MoneyInput: make outline, counter and label red on maxlength reached

![image](https://user-images.githubusercontent.com/70765247/146403930-6335534a-e99e-4eec-8d7a-a69ee449e9b6.png)
![image](https://user-images.githubusercontent.com/70765247/146410143-7201eed3-95d0-409f-864b-0ee02826950f.png)