### PR TITLE
TextField and TextArea: allow value > maxlength and add warning text

### DIFF
--- a/components/mdc/TextInput/TextArea.svelte
+++ b/components/mdc/TextInput/TextArea.svelte
@@ -21,7 +21,7 @@ let height = ''
 
 $: hasExceededMaxLength = maxlength && value.length > maxlength
 $: error = hasExceededMaxLength
-$: value & (value !== ' ') && addOrRemoveInvalidClass(error, element)
+$: value && value !== ' ' && addOrRemoveInvalidClass(error, element)
 
 onMount(() => {
   resize()
@@ -55,6 +55,15 @@ const focus = async (node) => {
 label {
   width: 100%;
 }
+.counter {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  -webkit-font-smoothing: antialiased;
+  font-family: var(--mdc-typography-caption-font-family, var(--mdc-typography-font-family, Roboto, sans-serif));
+  font-size: var(--mdc-typography-caption-font-size, 0.75rem);
+  font-weight: var(--mdc-typography-caption-font-weight, 400);
+}
 </style>
 
 <label
@@ -62,7 +71,6 @@ label {
   class:mdc-text-field--no-label={!label}
   class:mdc-text-field--label-floating={label}
   class:mdc-text-field--with-internal-counter={maxlength}
-  class:mdc-text-field--invalid={error}
   bind:this={element}
 >
   <textarea
@@ -84,7 +92,7 @@ label {
     on:blur
   />
   {#if maxlength}
-    <span class="mdc-text-field-character-counter" class:error>0 / {maxlength}</span>
+    <span class="counter gray mr-1 mb-4px" class:error>{value.length} / {maxlength}</span>
   {/if}
   <span class="mdc-notched-outline">
     <span class="mdc-notched-outline__leading" />

--- a/components/mdc/TextInput/TextArea.svelte
+++ b/components/mdc/TextInput/TextArea.svelte
@@ -1,5 +1,6 @@
 <!-- https://github.com/material-components/material-components-web/tree/master/packages/mdc-textfield -->
 <script>
+import { addOrRemoveInvalidClass } from '.'
 import { MDCTextField } from '@material/textfield'
 import { generateRandomID } from '../../../random'
 import { onMount, tick } from 'svelte'
@@ -18,8 +19,9 @@ let element = {}
 let textarea = {}
 let height = ''
 
-$: hasReachedMaxLength = maxlength && value.length >= maxlength
-$: error = hasReachedMaxLength
+$: hasExceededMaxLength = maxlength && value.length > maxlength
+$: error = hasExceededMaxLength
+$: value & (value !== ' ') && addOrRemoveInvalidClass(error, element)
 
 onMount(() => {
   resize()
@@ -60,15 +62,17 @@ label {
   class:mdc-text-field--no-label={!label}
   class:mdc-text-field--label-floating={label}
   class:mdc-text-field--with-internal-counter={maxlength}
-  class:mdc-text-field--invalid={hasReachedMaxLength}
+  class:mdc-text-field--invalid={error}
   bind:this={element}
 >
   <textarea
     class="mdc-text-field__input"
     class:rtl
     aria-labelledby={labelID}
+    aria-controls="{labelID}-helper-id"
+    aria-describedby="{labelID}-helper-id"
     {rows}
-    {maxlength}
+    maxlength="524288"
     {placeholder}
     bind:value
     use:focus
@@ -96,3 +100,10 @@ label {
     <span class="mdc-notched-outline__trailing" />
   </span>
 </label>
+<div class="mdc-text-field-helper-line">
+  <div class="mdc-text-field-helper-text" id="{labelID}-helper-id" aria-hidden="true">
+    {#if hasExceededMaxLength}
+      <span class="error">Maximum {maxlength} characters</span>
+    {/if}
+  </div>
+</div>

--- a/components/mdc/TextInput/TextField.svelte
+++ b/components/mdc/TextInput/TextField.svelte
@@ -77,6 +77,7 @@ const focus = (node) => autofocus && node.focus()
     on:keyup
     {required}
     {disabled}
+    maxlength="524288"
     {placeholder}
   />
   {#if error}

--- a/components/mdc/TextInput/TextField.svelte
+++ b/components/mdc/TextInput/TextField.svelte
@@ -1,5 +1,6 @@
 <!-- https://github.com/material-components/material-components-web/tree/master/packages/mdc-textfield -->
 <script>
+import { addOrRemoveInvalidClass } from '.'
 import { MDCTextField } from '@material/textfield'
 import { generateRandomID } from '../../../random'
 import { afterUpdate, onMount } from 'svelte'
@@ -20,16 +21,19 @@ let mdcTextField = {}
 let width = ''
 
 $: mdcTextField.value = value
-$: hasReachedMaxLength = maxlength && value.length >= maxlength
-$: error = hasReachedMaxLength
+$: hasExceededMaxLength = maxlength && value.length > maxlength
+$: error = hasExceededMaxLength
 $: showCounter = maxlength && value.length / maxlength > 0.85
+$: value && addOrRemoveInvalidClass(error, element)
 
 onMount(() => {
   mdcTextField = new MDCTextField(element)
   return () => mdcTextField.destroy()
 })
 
-afterUpdate(() => (width = `${element.offsetWidth}px`))
+afterUpdate(() => {
+  width = `${element.offsetWidth}px`
+})
 
 const focus = (node) => autofocus && node.focus()
 </script>
@@ -56,7 +60,6 @@ const focus = (node) => autofocus && node.focus()
   class="mdc-text-field mdc-text-field--outlined {$$props.class} textfield-radius"
   class:mdc-text-field--no-label={!label}
   class:mdc-text-field--disabled={disabled}
-  class:mdc-text-field--invalid={hasReachedMaxLength}
   bind:this={element}
 >
   <i class="material-icons" aria-hidden="true">{icon}</i>
@@ -73,11 +76,10 @@ const focus = (node) => autofocus && node.focus()
     on:keypress
     on:keyup
     {required}
-    {maxlength}
     {disabled}
     {placeholder}
   />
-  {#if hasReachedMaxLength}
+  {#if error}
     <span class="mdc-text-field__affix mdc-text-field__affix--suffix"
       ><i class="material-icons error" aria-hidden="true">error</i></span
     >
@@ -100,7 +102,7 @@ const focus = (node) => autofocus && node.focus()
     {#if required && !value}
       <span class="required">*Required</span>
     {/if}
-    {#if showCounter}
+    {#if error}
       <span class="error">Maximum {maxlength} characters</span>
     {/if}
   </div>

--- a/components/mdc/TextInput/index.js
+++ b/components/mdc/TextInput/index.js
@@ -4,3 +4,7 @@ import TextField from './TextField.svelte'
 import MoneyInput from './MoneyInput.svelte'
 
 export { TextArea, TextField, MoneyInput }
+
+export const addOrRemoveInvalidClass = async (isInvalid, element) => {
+  isInvalid ? element.classList.add('mdc-text-field--invalid') : element.classList.remove('mdc-text-field--invalid')
+}


### PR DESCRIPTION
# Add
- warning text to TextArea
# Change
- allow user to type more than maxlength but show error colors
![image](https://user-images.githubusercontent.com/70765247/146615282-77288b13-f02b-439f-9bee-159a75494392.png)
![image](https://user-images.githubusercontent.com/70765247/146615300-069a9f9b-64d6-462e-8e7b-4d18644c7454.png)
