### PR TITLE
Add required to TextArea and improvements 

### DIFF
--- a/components/mdc/TextInput/MoneyInput.svelte
+++ b/components/mdc/TextInput/MoneyInput.svelte
@@ -27,7 +27,8 @@ $: valueLength = value?.toString()?.length
 $: hasExceededMaxLength = maxlength && valueLength > maxlength
 $: hasExceededMaxValue = maxValue && internalValue > maxValue
 $: isLowerThanMinValue = minValue && internalValue < minValue
-$: error = hasExceededMaxValue || isLowerThanMinValue || hasExceededMaxLength || valueNotDivisibleByStep
+$: showErrorIcon = hasExceededMaxValue || isLowerThanMinValue || hasExceededMaxLength || valueNotDivisibleByStep
+$: error = showErrorIcon || (hasFocused && required && !internalValue)
 $: showCounter = maxlength && valueLength / maxlength > 0.85
 $: valueNotDivisibleByStep = internalValue && (internalValue / Number(step)) % 1 !== 0
 $: internalValue = Number(value) || ''
@@ -64,7 +65,7 @@ const focus = (node) => autofocus && node.focus()
   class:mdc-text-field--invalid={error}
   bind:this={element}
 >
-  <i class="material-icons" aria-hidden="true">attach_money</i>
+  <i class="material-icons" class:error aria-hidden="true">attach_money</i>
   <input
     {step}
     type="number"
@@ -86,7 +87,7 @@ const focus = (node) => autofocus && node.focus()
     {disabled}
     {placeholder}
   />
-  {#if error}
+  {#if showErrorIcon}
     <span class="mdc-text-field__affix mdc-text-field__affix--suffix"
       ><i class="material-icons error" aria-hidden="true">error</i></span
     >
@@ -107,8 +108,7 @@ const focus = (node) => autofocus && node.focus()
   <div class="mdc-text-field-helper-text" class:opacity1={required} id="{labelID}-helper-id" aria-hidden="true">
     {#if required && !internalValue}
       <span class="required" class:error={hasFocused}>*Required</span>
-    {/if}
-    {#if hasExceededMaxValue}
+    {:else if hasExceededMaxValue}
       <span class="error">Maximum value allowed is {maxValue}</span>
     {:else if isLowerThanMinValue}
       <span class="error">Minimun value allowed is ({minValue})</span>

--- a/components/mdc/TextInput/MoneyInput.svelte
+++ b/components/mdc/TextInput/MoneyInput.svelte
@@ -20,6 +20,7 @@ let maxlength = 524288 /* default */
 let element = {}
 let mdcTextField = {}
 let width = ''
+let hasFocused = false
 
 $: mdcTextField.value = value
 $: valueLength = value?.toString()?.length
@@ -48,9 +49,6 @@ const focus = (node) => autofocus && node.focus()
   top: 0.4rem;
   right: 0.6rem;
 }
-.required {
-  color: var(--mdc-required-input, var(--mdc-theme-status-error));
-}
 .label-margin {
   margin-left: 1.1rem;
 }
@@ -78,6 +76,7 @@ const focus = (node) => autofocus && node.focus()
     aria-describedby="{labelID}-helper-id"
     bind:value={internalValue}
     use:focus
+    on:focus={() => (hasFocused = true)}
     on:blur
     on:keydown
     on:keypress
@@ -105,9 +104,9 @@ const focus = (node) => autofocus && node.focus()
   </span>
 </label>
 <div class="mdc-text-field-helper-line" style="width: {width};">
-  <div class="mdc-text-field-helper-text" id="{labelID}-helper-id" aria-hidden="true">
+  <div class="mdc-text-field-helper-text" class:opacity1={required} id="{labelID}-helper-id" aria-hidden="true">
     {#if required && !internalValue}
-      <span class="required">*Required</span>
+      <span class="required" class:error={hasFocused}>*Required</span>
     {/if}
     {#if hasExceededMaxValue}
       <span class="error">Maximum value allowed is {maxValue}</span>

--- a/components/mdc/TextInput/MoneyInput.svelte
+++ b/components/mdc/TextInput/MoneyInput.svelte
@@ -27,8 +27,7 @@ $: valueLength = value?.toString()?.length
 $: hasExceededMaxLength = maxlength && valueLength > maxlength
 $: hasExceededMaxValue = maxValue && internalValue > maxValue
 $: isLowerThanMinValue = minValue && internalValue < minValue
-$: showErrorIcon = hasExceededMaxValue || isLowerThanMinValue || hasExceededMaxLength || valueNotDivisibleByStep
-$: error = showErrorIcon || (hasFocused && required && !internalValue)
+$: error = hasExceededMaxValue || isLowerThanMinValue || hasExceededMaxLength || valueNotDivisibleByStep
 $: showCounter = maxlength && valueLength / maxlength > 0.85
 $: valueNotDivisibleByStep = internalValue && (internalValue / Number(step)) % 1 !== 0
 $: internalValue = Number(value) || ''
@@ -87,7 +86,7 @@ const focus = (node) => autofocus && node.focus()
     {disabled}
     {placeholder}
   />
-  {#if showErrorIcon}
+  {#if error}
     <span class="mdc-text-field__affix mdc-text-field__affix--suffix"
       ><i class="material-icons error" aria-hidden="true">error</i></span
     >

--- a/components/mdc/TextInput/MoneyInput.svelte
+++ b/components/mdc/TextInput/MoneyInput.svelte
@@ -21,13 +21,15 @@ let element = {}
 let mdcTextField = {}
 let width = ''
 let hasFocused = false
+let hasBlurred = false
 
 $: mdcTextField.value = value
 $: valueLength = value?.toString()?.length
 $: hasExceededMaxLength = maxlength && valueLength > maxlength
 $: hasExceededMaxValue = maxValue && internalValue > maxValue
 $: isLowerThanMinValue = minValue && internalValue < minValue
-$: error = hasExceededMaxValue || isLowerThanMinValue || hasExceededMaxLength || valueNotDivisibleByStep
+$: showErrorIcon = hasExceededMaxValue || isLowerThanMinValue || hasExceededMaxLength || valueNotDivisibleByStep
+$: error = showErrorIcon || (hasFocused && hasBlurred && required && !value)
 $: showCounter = maxlength && valueLength / maxlength > 0.85
 $: valueNotDivisibleByStep = internalValue && (internalValue / Number(step)) % 1 !== 0
 $: internalValue = Number(value) || ''
@@ -78,6 +80,7 @@ const focus = (node) => autofocus && node.focus()
     use:focus
     on:focus={() => (hasFocused = true)}
     on:blur
+    on:blur={() => (hasBlurred = true)}
     on:keydown
     on:keypress
     on:keyup
@@ -86,10 +89,10 @@ const focus = (node) => autofocus && node.focus()
     {disabled}
     {placeholder}
   />
-  {#if error}
-    <span class="mdc-text-field__affix mdc-text-field__affix--suffix"
-      ><i class="material-icons error" aria-hidden="true">error</i></span
-    >
+  {#if showErrorIcon}
+    <span class="mdc-text-field__affix mdc-text-field__affix--suffix">
+      <i class="material-icons error" aria-hidden="true"> error</i>
+    </span>
   {/if}
   <span class="mdc-notched-outline">
     <span class="mdc-notched-outline__leading" />

--- a/components/mdc/TextInput/TextArea.svelte
+++ b/components/mdc/TextInput/TextArea.svelte
@@ -12,16 +12,19 @@ export let rows = 8
 export let maxlength = undefined
 export let autofocus = false
 export let rtl = false
+export let required = false
 
 const labelID = generateRandomID('textarea-label-')
 
 let element = {}
 let textarea = {}
 let height = ''
+let hasFocused = false
 
 $: hasExceededMaxLength = maxlength && value.length > maxlength
 $: error = hasExceededMaxLength
-$: value && value !== ' ' && addOrRemoveInvalidClass(error, element)
+$: valueIsEmpty = value === ' ' || !value
+$: !valueIsEmpty && addOrRemoveInvalidClass(error, element)
 
 onMount(() => {
   resize()
@@ -81,6 +84,7 @@ label {
     aria-describedby="{labelID}-helper-id"
     {rows}
     maxlength="524288"
+    {required}
     {placeholder}
     bind:value
     use:focus
@@ -89,6 +93,7 @@ label {
     on:input={resize}
     on:keydown
     on:focus
+    on:focus={() => (hasFocused = true)}
     on:blur
   />
   {#if maxlength}
@@ -109,7 +114,10 @@ label {
   </span>
 </label>
 <div class="mdc-text-field-helper-line">
-  <div class="mdc-text-field-helper-text" id="{labelID}-helper-id" aria-hidden="true">
+  <div class="mdc-text-field-helper-text" class:opacity1={required} id="{labelID}-helper-id" aria-hidden="true">
+    {#if required && valueIsEmpty}
+      <span class="required" class:error={hasFocused}>*Required</span>
+    {/if}
     {#if hasExceededMaxLength}
       <span class="error">Maximum {maxlength} characters</span>
     {/if}

--- a/components/mdc/TextInput/TextArea.svelte
+++ b/components/mdc/TextInput/TextArea.svelte
@@ -117,8 +117,7 @@ label {
   <div class="mdc-text-field-helper-text" class:opacity1={required} id="{labelID}-helper-id" aria-hidden="true">
     {#if required && valueIsEmpty}
       <span class="required" class:error={hasFocused}>*Required</span>
-    {/if}
-    {#if hasExceededMaxLength}
+    {:else if hasExceededMaxLength}
       <span class="error">Maximum {maxlength} characters</span>
     {/if}
   </div>

--- a/components/mdc/TextInput/TextArea.svelte
+++ b/components/mdc/TextInput/TextArea.svelte
@@ -20,9 +20,10 @@ let element = {}
 let textarea = {}
 let height = ''
 let hasFocused = false
+let hasBlurred = false
 
 $: hasExceededMaxLength = maxlength && value.length > maxlength
-$: error = hasExceededMaxLength
+$: error = hasExceededMaxLength || (hasFocused && hasBlurred && required && valueIsEmpty)
 $: valueIsEmpty = value === ' ' || !value
 $: !valueIsEmpty && addOrRemoveInvalidClass(error, element)
 
@@ -95,6 +96,7 @@ label {
     on:focus
     on:focus={() => (hasFocused = true)}
     on:blur
+    on:blur={() => (hasBlurred = true)}
   />
   {#if maxlength}
     <span class="counter gray mr-1 mb-4px" class:error>{value.length} / {maxlength}</span>

--- a/components/mdc/TextInput/TextField.svelte
+++ b/components/mdc/TextInput/TextField.svelte
@@ -20,10 +20,11 @@ let element = {}
 let mdcTextField = {}
 let width = ''
 let hasFocused = false
+let hasBlurred = false
 
 $: mdcTextField.value = value
 $: hasExceededMaxLength = maxlength && value.length > maxlength
-$: error = hasExceededMaxLength || (hasFocused && required && !value)
+$: error = hasExceededMaxLength || (hasFocused && hasBlurred && required && !value)
 $: showCounter = maxlength && value.length / maxlength > 0.85
 $: value && addOrRemoveInvalidClass(error, element)
 
@@ -70,6 +71,7 @@ const focus = (node) => autofocus && node.focus()
     bind:value
     use:focus
     on:focus={() => (hasFocused = true)}
+    on:blur={() => (hasBlurred = true)}
     on:blur
     on:keydown
     on:keypress

--- a/components/mdc/TextInput/TextField.svelte
+++ b/components/mdc/TextInput/TextField.svelte
@@ -19,6 +19,7 @@ const labelID = generateRandomID('text-label-')
 let element = {}
 let mdcTextField = {}
 let width = ''
+let hasFocused = false
 
 $: mdcTextField.value = value
 $: hasExceededMaxLength = maxlength && value.length > maxlength
@@ -45,9 +46,6 @@ const focus = (node) => autofocus && node.focus()
   top: 0.4rem;
   right: 0.6rem;
 }
-.required {
-  color: var(--mdc-required-input, var(--mdc-theme-status-error));
-}
 .label-margin {
   margin-left: 1.1rem;
 }
@@ -71,6 +69,7 @@ const focus = (node) => autofocus && node.focus()
     aria-describedby="{labelID}-helper-id"
     bind:value
     use:focus
+    on:focus={() => (hasFocused = true)}
     on:blur
     on:keydown
     on:keypress
@@ -101,7 +100,7 @@ const focus = (node) => autofocus && node.focus()
 <div class="mdc-text-field-helper-line" style="width: {width};">
   <div class="mdc-text-field-helper-text" class:opacity1={required} id="{labelID}-helper-id" aria-hidden="true">
     {#if required && !value}
-      <span class="required">*Required</span>
+      <span class="required" class:error={hasFocused}>*Required</span>
     {/if}
     {#if error}
       <span class="error">Maximum {maxlength} characters</span>

--- a/components/mdc/TextInput/TextField.svelte
+++ b/components/mdc/TextInput/TextField.svelte
@@ -23,7 +23,7 @@ let hasFocused = false
 
 $: mdcTextField.value = value
 $: hasExceededMaxLength = maxlength && value.length > maxlength
-$: error = hasExceededMaxLength
+$: error = hasExceededMaxLength || (hasFocused && required && !value)
 $: showCounter = maxlength && value.length / maxlength > 0.85
 $: value && addOrRemoveInvalidClass(error, element)
 
@@ -60,7 +60,7 @@ const focus = (node) => autofocus && node.focus()
   class:mdc-text-field--disabled={disabled}
   bind:this={element}
 >
-  <i class="material-icons" aria-hidden="true">{icon}</i>
+  <i class="material-icons" class:error aria-hidden="true">{icon}</i>
   <input
     type="text"
     class="mdc-text-field__input"
@@ -79,7 +79,7 @@ const focus = (node) => autofocus && node.focus()
     maxlength="524288"
     {placeholder}
   />
-  {#if error}
+  {#if hasExceededMaxLength}
     <span class="mdc-text-field__affix mdc-text-field__affix--suffix"
       ><i class="material-icons error" aria-hidden="true">error</i></span
     >
@@ -101,8 +101,7 @@ const focus = (node) => autofocus && node.focus()
   <div class="mdc-text-field-helper-text" class:opacity1={required} id="{labelID}-helper-id" aria-hidden="true">
     {#if required && !value}
       <span class="required" class:error={hasFocused}>*Required</span>
-    {/if}
-    {#if error}
+    {:else if hasExceededMaxLength}
       <span class="error">Maximum {maxlength} characters</span>
     {/if}
   </div>

--- a/components/mdc/TextInput/_index.scss
+++ b/components/mdc/TextInput/_index.scss
@@ -18,3 +18,6 @@
 .error {
   color: var(--mdc-theme-status-error, var(--mdc-theme-error)) !important;
 }
+.required {
+  color: var(--mdc-required-input, rgba(0, 0, 0, 0.6));
+}

--- a/stories/TextArea.stories.svelte
+++ b/stories/TextArea.stories.svelte
@@ -31,3 +31,5 @@ const args = {
 <Story name="rows" args={copyAndModifyArgs(args, { rows: 2 })} />
 
 <Story name="Autofocus" args={copyAndModifyArgs(args, { autofocus: true })} />
+
+<Story name="Required" args={copyAndModifyArgs(args, { required: true })} />

--- a/stories/_theme.scss
+++ b/stories/_theme.scss
@@ -5,7 +5,7 @@
   --mdc-theme-primary-variant: #0078af;
   --mdc-theme-secondary: #ff4800;
   --mdc-theme-error: #c30000;
-  --mdc-required-input: #da1414;
+  --mdc-required-input: gray;
   --progress-bar-color: #005cb9;
   --main-content-height: unset;
 }


### PR DESCRIPTION
- Add required to TextArea
- show "*Required" before `on:focus`, but default to gray instead of red in all TextInput elements
- turn "*Required" red `on:focus` (this could alternatively be done `on:blur`)
- fix label not turning red `on:blur`, prepend icon not turning red when field is still empty

![frame1](https://user-images.githubusercontent.com/70765247/146979063-611a379b-995c-4a87-b143-78db8ff21476.PNG)
![frame2](https://user-images.githubusercontent.com/70765247/146979076-dc888116-0ea5-4dda-b99e-e26f43178101.PNG)
![frame3](https://user-images.githubusercontent.com/70765247/146979108-647f29e8-4f27-4721-a94b-7d34807dd553.PNG)
![frame4](https://user-images.githubusercontent.com/70765247/146979114-1e1b2a44-92f3-490e-a97f-3b6834465f49.PNG)
![frame5](https://user-images.githubusercontent.com/70765247/146979117-648befbe-3434-4fe3-9697-7917438659a4.PNG)