### PR TITLE
fix(Drawer): fix a11y warning

### DIFF
--- a/components/mdc/Drawer/Drawer.svelte
+++ b/components/mdc/Drawer/Drawer.svelte
@@ -159,10 +159,7 @@ main {
                 {/if}
               </a>
             {:else}
-              <hr
-                class="mdc-list-divider mdc-list-divider--inset-leading mdc-list-divider--inset-trailing"
-                role="separator"
-              />
+              <hr class="mdc-list-divider mdc-list-divider--inset-leading mdc-list-divider--inset-trailing" />
             {/if}
           </Tooltip.Wrapper>
           {#if tooltip}


### PR DESCRIPTION
# Fix
- warning "Plugin svelte: A11y: Redundant role 'separator'"