### PR TITLE
fix(MoneyInput): fix step bug when 2.01 is entered

### DIFF
--- a/components/mdc/TextInput/MoneyInput.svelte
+++ b/components/mdc/TextInput/MoneyInput.svelte
@@ -31,7 +31,7 @@ $: isLowerThanMinValue = minValue && internalValue < minValue
 $: showErrorIcon = hasExceededMaxValue || isLowerThanMinValue || hasExceededMaxLength || valueNotDivisibleByStep
 $: error = showErrorIcon || (hasFocused && hasBlurred && required && !internalValue)
 $: showCounter = maxlength && valueLength / maxlength > 0.85
-$: valueNotDivisibleByStep = internalValue && (internalValue / Number(step)) % 1 !== 0
+$: valueNotDivisibleByStep = internalValue && (internalValue / Number(step)).toFixed(13) % 1 !== 0
 $: internalValue = Number(value) || 0
 
 onMount(() => {


### PR DESCRIPTION
#Fixed
- bug when 2.01 and other numbers are entered

before
![image](https://user-images.githubusercontent.com/70765247/156714123-03326a16-0611-44d2-87c3-88dec6da165e.png)

after
![image](https://user-images.githubusercontent.com/70765247/156713884-d8ddcfc7-190b-47b7-89c4-32a31215ef23.png)
