### PR TITLE
fix(MoneyInput): fix 1x10e-n not being caught by step

### DIFF
--- a/components/mdc/TextInput/MoneyInput.svelte
+++ b/components/mdc/TextInput/MoneyInput.svelte
@@ -1,7 +1,8 @@
 <!-- https://github.com/material-components/material-components-web/tree/master/packages/mdc-textfield -->
 <script>
-import { MDCTextField } from '@material/textfield'
+import { getDecimalPlacesLength } from './helpers'
 import { generateRandomID } from '../../../random'
+import { MDCTextField } from '@material/textfield'
 import { afterUpdate, onMount } from 'svelte'
 
 export let label = ''
@@ -42,12 +43,6 @@ onMount(() => {
 })
 
 afterUpdate(() => (width = `${element?.offsetWidth}px`))
-
-function getDecimalPlacesLength(number = 0) {
-  const string = String(number)
-  const length = string.includes('e-') ? string.split('e-')?.[1] : string.split('.')[1]?.length
-  return length || 0
-}
 
 const focus = (node) => autofocus && node.focus()
 </script>

--- a/components/mdc/TextInput/MoneyInput.svelte
+++ b/components/mdc/TextInput/MoneyInput.svelte
@@ -31,7 +31,9 @@ $: isLowerThanMinValue = minValue && internalValue < minValue
 $: showErrorIcon = hasExceededMaxValue || isLowerThanMinValue || hasExceededMaxLength || valueNotDivisibleByStep
 $: error = showErrorIcon || (hasFocused && hasBlurred && required && !internalValue)
 $: showCounter = maxlength && valueLength / maxlength > 0.85
-$: valueNotDivisibleByStep = internalValue && (internalValue / Number(step)).toFixed(2) % 1 !== 0
+$: valueHasTooManyDecPlaces = getDecimalPlacesLength(internalValue) > getDecimalPlacesLength(step)
+$: valueNotDivisibleByStep =
+  (internalValue && (internalValue / Number(step)).toFixed(2) % 1 !== 0) || valueHasTooManyDecPlaces
 $: internalValue = Number(value) || 0
 
 onMount(() => {
@@ -40,6 +42,12 @@ onMount(() => {
 })
 
 afterUpdate(() => (width = `${element?.offsetWidth}px`))
+
+function getDecimalPlacesLength(number = 0) {
+  const string = String(number)
+  const length = string.includes('e-') ? string.split('e-')?.[1] : string.split('.')[1]?.length
+  return length || 0
+}
 
 const focus = (node) => autofocus && node.focus()
 </script>

--- a/components/mdc/TextInput/helpers.js
+++ b/components/mdc/TextInput/helpers.js
@@ -5,5 +5,5 @@ export const addOrRemoveInvalidClass = async (isInvalid, element) => {
 export function getDecimalPlacesLength(number = 0) {
   const string = String(number)
   const length = string.includes('e-') ? string.split('e-')?.[1] : string.split('.')[1]?.length
-  return length || 0
+  return Number(length || 0)
 }

--- a/components/mdc/TextInput/helpers.js
+++ b/components/mdc/TextInput/helpers.js
@@ -1,3 +1,9 @@
 export const addOrRemoveInvalidClass = async (isInvalid, element) => {
   isInvalid ? element.classList?.add('mdc-text-field--invalid') : element.classList?.remove('mdc-text-field--invalid')
 }
+
+export function getDecimalPlacesLength(number = 0) {
+  const string = String(number)
+  const length = string.includes('e-') ? string.split('e-')?.[1] : string.split('.')[1]?.length
+  return length || 0
+}

--- a/stories/MoneyInput.stories.svelte
+++ b/stories/MoneyInput.stories.svelte
@@ -1,8 +1,12 @@
 <script>
-import { Meta, Template, Story } from '@storybook/addon-svelte-csf'
 import { MoneyInput } from '../components/mdc'
 import { copyAndModifyArgs } from './helpers.js'
+import { Meta, Template, Story } from '@storybook/addon-svelte-csf'
+import { getDecimalPlacesLength } from '../components/mdc/TextInput/helpers'
 
+let arrayOfValues = []
+let dynamicValue
+let lastKey = ''
 let title = 'MoneyInput'
 
 const args = {
@@ -14,14 +18,38 @@ const args = {
   maxValue: 100,
   step: '.01',
 }
+$: arrayOfValues.forEach((v) =>
+  setTimeout(() => {
+    dynamicValue = v
+  }, 100)
+)
 
-let lastKey = ''
+//https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from#sequence_generator_range
+function range(start, stop, step) {
+  const numberOfDecToFix = getDecimalPlacesLength(step)
+  return Array.from({ length: (stop - start) / step + 1 }, (_, i) => start + (i * step).toFixed(numberOfDecToFix))
+}
+
+function setValues(max, step) {
+  arrayOfValues = range(0, max, step)
+}
 </script>
 
 <Meta title="Atoms/MoneyInput" component={MoneyInput} />
 
 <Template let:args>
-  <MoneyInput {...args} on:keydown={args['on:keydown']} on:keypress={args['on:keypress']} on:keyup={args['on:keyup']} />
+  {#if !args.label}
+    <div class="opacity0">
+      {setValues(args.maxValue, args.step)}
+    </div>
+  {/if}
+  <MoneyInput
+    value={!args.label && dynamicValue}
+    {...args}
+    on:keydown={args['on:keydown']}
+    on:keypress={args['on:keypress']}
+    on:keyup={args['on:keyup']}
+  />
   {#if lastKey}
     <p>Last key pressed: {lastKey}</p>
   {/if}
@@ -46,3 +74,5 @@ let lastKey = ''
 <Story name="Disabled" args={copyAndModifyArgs(args, { disabled: true })} />
 
 <Story name="Description" args={copyAndModifyArgs(args, { description: 'a description' })} />
+
+<Story name="Test step" args={{ ...args, label: '' }} />

--- a/stories/MoneyInput.stories.svelte
+++ b/stories/MoneyInput.stories.svelte
@@ -35,11 +35,18 @@ function setValues(max, step) {
 }
 </script>
 
+<style>
+  .d-none {
+  display: none;
+}
+
+</style>
+
 <Meta title="Atoms/MoneyInput" component={MoneyInput} />
 
 <Template let:args>
   {#if !args.label}
-    <div class="opacity0">
+    <div class="d-none">
       {setValues(args.maxValue, args.step)}
     </div>
   {/if}


### PR DESCRIPTION
### Fixed
- small floats don't get caught by `%` or really small ones get converted to strings as "1x10e-[n]" and don't get caught

### Added
- a MoneyInput testing story in Storybook
![image](https://user-images.githubusercontent.com/70765247/162099149-f1fa6835-b9d1-4aef-9e4d-ab180a9f0b56.png)
![moneyInputTest](https://user-images.githubusercontent.com/70765247/162133035-593847c6-8cf5-4a45-8dc7-5ba3473750a8.gif)

