### PR TITLE
Add datatable checkbox component/story and improve TabBar story docs

### DIFF
--- a/components/mdc/Datatable/DataRow.svelte
+++ b/components/mdc/Datatable/DataRow.svelte
@@ -7,5 +7,5 @@ const rowId = generateRandomID('row-id-')
 </script>
 
 <tr on:click on:keydown data-row-id={rowId} class="mdc-data-table__row {$$props.class}" class:pointer={clickable}>
-  <slot />
+  <slot {rowId} />
 </tr>

--- a/components/mdc/Datatable/DataRow.svelte
+++ b/components/mdc/Datatable/DataRow.svelte
@@ -1,7 +1,11 @@
 <script>
+import { generateRandomID } from '../../../random'
+
 export let clickable = false
+
+const rowId = generateRandomID('row-id-')
 </script>
 
-<tr on:click on:keydown class="mdc-data-table__row {$$props.class}" class:pointer={clickable}>
+<tr on:click on:keydown data-row-id={rowId} class="mdc-data-table__row {$$props.class}" class:pointer={clickable}>
   <slot />
 </tr>

--- a/components/mdc/Datatable/Datatable.svelte
+++ b/components/mdc/Datatable/Datatable.svelte
@@ -37,8 +37,6 @@ onMount(() => {
     dispatch('rowSelectionChanged', event.detail)
   })
 
-  // This does not work because of an MDC bug. See https://github.com/material-components/material-components-web/issues/6385
-  // If checkboxes are needed, check for a release of the PR linked to the above issue, or pull in the destroy code here.
   return () => dataTable.destroy()
 })
 

--- a/components/mdc/Datatable/Datatable.svelte
+++ b/components/mdc/Datatable/Datatable.svelte
@@ -2,15 +2,24 @@
 <script>
 import { MDCDataTable } from '@material/data-table'
 import { createEventDispatcher, onMount } from 'svelte'
-
+/**
+ * @prop {string}
+ * @description used for aria-label
+ */
 export let label = ''
+/**
+ * @prop {any}
+ * @description used to register new Datatable Checkboxes when length changes
+ */
+export let checkboxIsMountedArray = []
 
 const dispatch = createEventDispatcher()
+let dataTable = {}
 
 let element = {}
 
 onMount(() => {
-  const dataTable = new MDCDataTable(element)
+  dataTable = new MDCDataTable(element)
 
   dataTable.listen('MDCDataTable:sorted', (event) => {
     dispatch('sorted', event.detail)
@@ -30,8 +39,10 @@ onMount(() => {
 
   // This does not work because of an MDC bug. See https://github.com/material-components/material-components-web/issues/6385
   // If checkboxes are needed, check for a release of the PR linked to the above issue, or pull in the destroy code here.
-  //return () => dataTable.destroy()
+  return () => dataTable.destroy()
 })
+
+$: checkboxIsMountedArray.length && dataTable?.layout()
 </script>
 
 <div class="mdc-data-table w-100 {$$props.class}" bind:this={element}>

--- a/components/mdc/Datatable/Datatable.svelte
+++ b/components/mdc/Datatable/Datatable.svelte
@@ -8,10 +8,10 @@ import { createEventDispatcher, onMount } from 'svelte'
  */
 export let label = ''
 /**
- * @prop {any}
- * @description used to register new Datatable Checkboxes when length changes
+ * @prop {number}
+ * @description used to register new Datatable Checkboxes when value changes
  */
-export let checkboxIsMountedArray = []
+export let numberOfCheckboxes = 0
 
 const dispatch = createEventDispatcher()
 let dataTable = {}
@@ -40,7 +40,7 @@ onMount(() => {
   return () => dataTable.destroy()
 })
 
-$: checkboxIsMountedArray.length && dataTable?.layout()
+$: numberOfCheckboxes && dataTable?.layout()
 </script>
 
 <div class="mdc-data-table w-100 {$$props.class}" bind:this={element}>

--- a/components/mdc/Datatable/Datatable.svelte
+++ b/components/mdc/Datatable/Datatable.svelte
@@ -16,6 +16,18 @@ onMount(() => {
     dispatch('sorted', event.detail)
   })
 
+  dataTable.listen('MDCDataTable:selectedAll', () => {
+    dispatch('selectedAll')
+  })
+
+  dataTable.listen('MDCDataTable:unselectedAll', () => {
+    dispatch('unselectedAll')
+  })
+
+  dataTable.listen('MDCDataTable:rowSelectionChanged', (event) => {
+    dispatch('rowSelectionChanged', event.detail)
+  })
+
   // This does not work because of an MDC bug. See https://github.com/material-components/material-components-web/issues/6385
   // If checkboxes are needed, check for a release of the PR linked to the above issue, or pull in the destroy code here.
   //return () => dataTable.destroy()

--- a/components/mdc/Datatable/DatatableCheckbox.svelte
+++ b/components/mdc/Datatable/DatatableCheckbox.svelte
@@ -1,0 +1,31 @@
+<script>
+import { generateRandomID } from '../../../random'
+import { createEventDispatcher } from 'svelte'
+
+export let disabled = false
+
+let checked = false
+
+const inputID = generateRandomID('checkbox-')
+
+$: checked, handleChange()
+
+const dispatch = createEventDispatcher()
+
+const handleChange = () => {
+  dispatch('change')
+}
+</script>
+
+<td class="mdc-data-table__cell mdc-data-table__cell--checkbox" on:click>
+  <div class="mdc-checkbox mdc-data-table__row-checkbox">
+    <input type="checkbox" class="mdc-checkbox__native-control" aria-labelledby={inputID} {disabled} bind:checked />
+    <div class="mdc-checkbox__background">
+      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
+        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
+      </svg>
+      <div class="mdc-checkbox__mixedmark" />
+    </div>
+    <div class="mdc-checkbox__ripple" />
+  </div>
+</td>

--- a/components/mdc/Datatable/DatatableCheckbox.svelte
+++ b/components/mdc/Datatable/DatatableCheckbox.svelte
@@ -1,12 +1,14 @@
 <script>
 import { generateRandomID } from '../../../random'
-import { createEventDispatcher } from 'svelte'
+import { createEventDispatcher, onMount } from 'svelte'
 
 export let disabled = false
 
-let checked = false
+let checked
 
 const inputID = generateRandomID('checkbox-')
+
+onMount(() => dispatch('mounted'))
 
 $: checked, handleChange()
 

--- a/components/mdc/Datatable/DatatableCheckbox.svelte
+++ b/components/mdc/Datatable/DatatableCheckbox.svelte
@@ -1,27 +1,17 @@
 <script>
-import { generateRandomID } from '../../../random'
 import { createEventDispatcher, onMount } from 'svelte'
 
 export let disabled = false
-
-let checked
-
-const inputID = generateRandomID('checkbox-')
+export let rowId = ''
 
 onMount(() => dispatch('mounted'))
 
-$: checked, handleChange()
-
 const dispatch = createEventDispatcher()
-
-const handleChange = () => {
-  dispatch('change')
-}
 </script>
 
 <td class="mdc-data-table__cell mdc-data-table__cell--checkbox" on:click>
   <div class="mdc-checkbox mdc-data-table__row-checkbox">
-    <input type="checkbox" class="mdc-checkbox__native-control" aria-labelledby={inputID} {disabled} bind:checked />
+    <input type="checkbox" class="mdc-checkbox__native-control" aria-labelledby={rowId} {disabled} />
     <div class="mdc-checkbox__background">
       <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
         <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59" />

--- a/components/mdc/Datatable/DatatableCheckboxHeader.svelte
+++ b/components/mdc/Datatable/DatatableCheckboxHeader.svelte
@@ -1,0 +1,12 @@
+<th class="mdc-data-table__header-cell mdc-data-table__header-cell--checkbox" role="columnheader" scope="col">
+  <div class="mdc-checkbox mdc-data-table__header-row-checkbox">
+    <input type="checkbox" class="mdc-checkbox__native-control" aria-label="Toggle all rows" />
+    <div class="mdc-checkbox__background">
+      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
+        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
+      </svg>
+      <div class="mdc-checkbox__mixedmark" />
+    </div>
+    <div class="mdc-checkbox__ripple" />
+  </div>
+</th>

--- a/components/mdc/Datatable/_index.scss
+++ b/components/mdc/Datatable/_index.scss
@@ -1,4 +1,6 @@
-@use '@material/data-table/data-table';
+@use "@material/checkbox"; // Required only for data table with row selection.
+@use "@material/data-table/data-table";
 
+@include checkbox.core-styles;
 @include data-table.core-styles;
 @include data-table.theme-baseline;

--- a/components/mdc/Datatable/index.js
+++ b/components/mdc/Datatable/index.js
@@ -5,11 +5,15 @@ import DataRow from './DataRow.svelte'
 import DataRowItem from './DataRowItem.svelte'
 import Header from './Header.svelte'
 import HeaderItem from './HeaderItem.svelte'
+import DatatableCheckbox from './DatatableCheckbox.svelte'
+import DatatableCheckboxHeader from './DatatableCheckboxHeader.svelte'
 
 Datatable.Data = Data
 Datatable.Data.Row = DataRow
 Datatable.Data.Row.Item = DataRowItem
 Datatable.Header = Header
 Datatable.Header.Item = HeaderItem
+Datatable.Header.Checkbox = DatatableCheckboxHeader
+Datatable.Checkbox = DatatableCheckbox
 
 export default Datatable

--- a/stories/Datatable.stories.svelte
+++ b/stories/Datatable.stories.svelte
@@ -83,8 +83,8 @@ onMount(() =>
     </Datatable.Header>
 
     <Datatable.Data>
-      <Datatable.Data.Row clickable={args.clickable}>
-        <Datatable.Checkbox />
+      <Datatable.Data.Row clickable={args.clickable} let:rowId>
+        <Datatable.Checkbox {rowId} />
         <Datatable.Data.Row.Item>item</Datatable.Data.Row.Item>
         <Datatable.Data.Row.Item>today</Datatable.Data.Row.Item>
       </Datatable.Data.Row>

--- a/stories/Datatable.stories.svelte
+++ b/stories/Datatable.stories.svelte
@@ -1,13 +1,15 @@
 <script>
-import { Meta, Template, Story } from '@storybook/addon-svelte-csf'
+import { Meta, Story } from '@storybook/addon-svelte-csf'
 import { Datatable, isAboveMobile, isAboveTablet, Progress } from '../components/mdc'
-import { copyAndModifyArgs } from './helpers.js'
 import { onMount } from 'svelte'
 
 const args = {
   class: '', //only works for global classes
-  onSorted: () => {},
-  clickable: false,
+  'on:sorted': (e) => alert('you sorted the table'),
+  'on:selectedAll': (e) => alert('you selected all rows'),
+  'on:unselectedAll': (e) => alert('you unselected all rows'),
+  'on:rowSelectionChanged': (e) => alert(`row ${e.detail.rowId} was ${e.detail.selected ? 'selected' : 'unselected'}`),
+  'on:click': (e) => alert(`you clicked on row ${e.detail}`),
 }
 
 let loaded = false
@@ -19,10 +21,23 @@ onMount(() =>
 )
 </script>
 
-<Meta title="Molecule/Datatable" component={Datatable} />
+<Meta
+  title="Molecule/Datatable"
+  component={Datatable}
+  argTypes={{
+    label: { control: 'text' },
+    clickable: { control: 'boolean' },
+  }}
+/>
 
-<Template let:args>
-  <Datatable {...args} on:sorted={args.onSorted}>
+<Story name="Default" {args}>
+  <Datatable
+    class={args.class}
+    on:sorted={args['on:sorted']}
+    on:rowSelectionChanged={args['on:rowSelectionChanged']}
+    on:unselectedAll={args['on:unselectedAll']}
+    on:selectedAll={args['on:selectedAll']}
+  >
     <Datatable.Header>
       <Datatable.Header.Item class={isAboveTablet() ? 'w-50' : ''}>Name</Datatable.Header.Item>
       <Datatable.Header.Item>Date</Datatable.Header.Item>
@@ -51,10 +66,117 @@ onMount(() =>
       </Datatable.Data.Row>
     </Datatable.Data>
   </Datatable>
-</Template>
+</Story>
 
-<Story name="Default" {args} />
+<Story name="Checkbox" {args}>
+  <Datatable
+    class={args.class}
+    on:sorted={args['on:sorted']}
+    on:rowSelectionChanged={args['on:rowSelectionChanged']}
+    on:unselectedAll={args['on:unselectedAll']}
+    on:selectedAll={args['on:selectedAll']}
+  >
+    <Datatable.Header>
+      <Datatable.Header.Checkbox />
+      <Datatable.Header.Item class={isAboveTablet() ? 'w-50' : ''}>Name</Datatable.Header.Item>
+      <Datatable.Header.Item>Date</Datatable.Header.Item>
+    </Datatable.Header>
 
-<Story name="Label" args={copyAndModifyArgs(args, { label: 'label' })} />
+    <Datatable.Data>
+      <Datatable.Data.Row clickable={args.clickable}>
+        <Datatable.Checkbox />
+        <Datatable.Data.Row.Item>item</Datatable.Data.Row.Item>
+        <Datatable.Data.Row.Item>today</Datatable.Data.Row.Item>
+      </Datatable.Data.Row>
 
-<Story name="Clickable row" args={copyAndModifyArgs(args, { clickable: 'true' })} />
+      <Datatable.Data.Row>
+        <Datatable.Checkbox />
+        <Datatable.Data.Row.Item>item2</Datatable.Data.Row.Item>
+        <Datatable.Data.Row.Item>tomorrow</Datatable.Data.Row.Item>
+      </Datatable.Data.Row>
+
+      <Datatable.Data.Row>
+        <Datatable.Checkbox />
+        <Datatable.Data.Row.Item colspan={isAboveMobile() ? 6 : 2}>
+          {#if loaded}
+            Done loading
+          {:else}
+            Loading...
+            <Progress.Linear barColorProvided={false} indeterminate />
+          {/if}
+        </Datatable.Data.Row.Item>
+      </Datatable.Data.Row>
+    </Datatable.Data>
+  </Datatable>
+</Story>
+
+<Story name="Label">
+  <Datatable
+    class={args.class}
+    label={'Label'}
+    on:sorted={args['on:sorted']}
+    on:rowSelectionChanged={args['on:rowSelectionChanged']}
+    on:unselectedAll={args['on:unselectedAll']}
+    on:selectedAll={args['on:selectedAll']}
+  >
+    <Datatable.Header>
+      <Datatable.Header.Item class={isAboveTablet() ? 'w-50' : ''}>Name</Datatable.Header.Item>
+      <Datatable.Header.Item>Date</Datatable.Header.Item>
+    </Datatable.Header>
+
+    <Datatable.Data>
+      <Datatable.Data.Row clickable={args.clickable}>
+        <Datatable.Data.Row.Item>item</Datatable.Data.Row.Item>
+        <Datatable.Data.Row.Item>today</Datatable.Data.Row.Item>
+      </Datatable.Data.Row>
+
+      <Datatable.Data.Row>
+        <Datatable.Data.Row.Item>item2</Datatable.Data.Row.Item>
+        <Datatable.Data.Row.Item>tomorrow</Datatable.Data.Row.Item>
+      </Datatable.Data.Row>
+
+      <Datatable.Data.Row>
+        <Datatable.Data.Row.Item colspan={isAboveMobile() ? 6 : 2}>
+          {#if loaded}
+            Done loading
+          {:else}
+            Loading...
+            <Progress.Linear barColorProvided={false} indeterminate />
+          {/if}
+        </Datatable.Data.Row.Item>
+      </Datatable.Data.Row>
+    </Datatable.Data>
+  </Datatable>
+</Story>
+
+<Story name="Clickable row">
+  <Datatable class={args.class} on:sorted={args['on:sorted']}>
+    <Datatable.Header>
+      <Datatable.Header.Item class={isAboveTablet() ? 'w-50' : ''}>Name</Datatable.Header.Item>
+      <Datatable.Header.Item>Date</Datatable.Header.Item>
+    </Datatable.Header>
+
+    <Datatable.Data>
+      <Datatable.Data.Row on:click={args['on:click']} clickable="true}">
+        <Datatable.Data.Row.Item>item</Datatable.Data.Row.Item>
+        <Datatable.Data.Row.Item>today</Datatable.Data.Row.Item>
+      </Datatable.Data.Row>
+
+      <Datatable.Data.Row on:click={args['on:click']} clickable="true}">
+        <Datatable.Data.Row.Item>item2</Datatable.Data.Row.Item>
+        <Datatable.Data.Row.Item>tomorrow</Datatable.Data.Row.Item>
+      </Datatable.Data.Row>
+
+      <Datatable.Data.Row on:click={args['on:click']} clickable="true}">
+        <Datatable.Data.Row.Item colspan={isAboveMobile() ? 6 : 2}>
+          {#if loaded}
+            Done loading
+          {:else}
+            Loading...
+            <Progress.Linear barColorProvided={false} indeterminate />
+          {/if}
+        </Datatable.Data.Row.Item>
+      </Datatable.Data.Row>
+    </Datatable.Data>
+  </Datatable>
+</Story>

--- a/stories/Datatable.stories.svelte
+++ b/stories/Datatable.stories.svelte
@@ -13,6 +13,7 @@ const args = {
 }
 
 let loaded = false
+let numberOfCheckboxes = 0
 
 onMount(() =>
   setTimeout(() => {
@@ -70,6 +71,7 @@ onMount(() =>
 
 <Story name="Checkbox" {args}>
   <Datatable
+    {numberOfCheckboxes}
     class={args.class}
     on:sorted={args['on:sorted']}
     on:rowSelectionChanged={args['on:rowSelectionChanged']}
@@ -84,19 +86,19 @@ onMount(() =>
 
     <Datatable.Data>
       <Datatable.Data.Row clickable={args.clickable} let:rowId>
-        <Datatable.Checkbox {rowId} />
+        <Datatable.Checkbox on:mounted={() => numberOfCheckboxes++} {rowId} />
         <Datatable.Data.Row.Item>item</Datatable.Data.Row.Item>
         <Datatable.Data.Row.Item>today</Datatable.Data.Row.Item>
       </Datatable.Data.Row>
 
       <Datatable.Data.Row>
-        <Datatable.Checkbox />
+        <Datatable.Checkbox on:mounted={() => numberOfCheckboxes++} />
         <Datatable.Data.Row.Item>item2</Datatable.Data.Row.Item>
         <Datatable.Data.Row.Item>tomorrow</Datatable.Data.Row.Item>
       </Datatable.Data.Row>
 
       <Datatable.Data.Row>
-        <Datatable.Checkbox />
+        <Datatable.Checkbox on:mounted={() => numberOfCheckboxes++} />
         <Datatable.Data.Row.Item colspan={isAboveMobile() ? 6 : 2}>
           {#if loaded}
             Done loading

--- a/stories/TabBar.stories.svelte
+++ b/stories/TabBar.stories.svelte
@@ -1,5 +1,5 @@
 <script>
-import { Meta, Template, Story } from '@storybook/addon-svelte-csf'
+import { Meta, Story } from '@storybook/addon-svelte-csf'
 import { TabBar } from '../components/mdc'
 
 const args = {
@@ -9,16 +9,14 @@ const args = {
 }
 </script>
 
-<Meta title="Atoms/TabBar" component={TabBar} />
+<Meta title="Molecule/TabBar" component={TabBar} />
 
-<Template let:args>
-  <TabBar {...args}>
+<Story name="Default" {args}>
+  <TabBar tab={args.tab}>
     <TabBar.Scroller>
       <TabBar.Tab label="tab 1" on:click={args['on:click']} active={args.tab === 0} />
       <TabBar.Tab label="tab 2" on:click={args['on:click']} active={args.tab === 1} />
       <TabBar.Tab label="tab 3" on:click={args['on:click']} active={args.tab === 2} />
     </TabBar.Scroller>
   </TabBar>
-</Template>
-
-<Story name="Default" {args} />
+</Story>


### PR DESCRIPTION
- added Datatable.Header.Checkbox and Datatable.Checkbox subcomponents
- Datatable now emits events for checkboxes (as opposed to how we were using checkbox in cover)
- added to and improved story/documentation to show subcomponents in Datatable and TabBAr
- docs now renders all the subcomponents but shows {...args} instead of props for Datatable and TabBar
- added numberOfCheckboxes to Datatable to register new Checkboxes which fixes an exception