### PR TITLE
fix(peerDependencies): update material-components-web and sass to mat…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,8 +34,8 @@
         "svelte-preprocess": "^4.10.7"
       },
       "peerDependencies": {
-        "material-components-web": "^13.0.0",
-        "sass": "1.50.x",
+        "material-components-web": "^14.0.0",
+        "sass": "1.55.x",
         "svelte": "^3.x"
       }
     },

--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
   },
   "homepage": "https://github.com/silinternational/ui-components#readme",
   "peerDependencies": {
-    "material-components-web": "^13.0.0",
+    "material-components-web": "^14.0.0",
     "svelte": "^3.x",
-    "sass": "1.50.x"
+    "sass": "1.55.x"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.1",


### PR DESCRIPTION
- update material-components-web and sass to match devDependencies.
- Fixes an npm error/warning for consumers using material-components-web@14 and sass@1.55