### PR TITLE
Form listens for reset on self

### DIFF
--- a/components/custom/Form/Form.svelte
+++ b/components/custom/Form/Form.svelte
@@ -22,7 +22,7 @@ $: success && resetForm(form)
 
 const resetForm = (form) => {
   console.warn(
-    '@silintl/ui-components: success prop is deprecated, use `Form on:submit={(event) => event.target.reset()} instead'
+    '@silintl/ui-components: success prop is deprecated, use `Form on:submit={(event) => event.target.reset()}` instead'
   )
   form.reset()
   sessionStorage.removeItem(id)

--- a/components/custom/Form/Form.svelte
+++ b/components/custom/Form/Form.svelte
@@ -16,6 +16,9 @@ $: saveToLocalStorage && restoreFormValues(form)
 $: success && resetForm(form)
 
 const resetForm = (form) => {
+  console.warn(
+    '@silintl/ui-components: success prop is deprecated, use `form on:submit={(event) => event.target.reset()} instead'
+  )
   form.reset()
   sessionStorage.removeItem(id)
 }

--- a/components/custom/Form/Form.svelte
+++ b/components/custom/Form/Form.svelte
@@ -4,7 +4,7 @@ import { generateRandomID } from '../../../random'
 
 export let id = generateRandomID('form-')
 export let saveToLocalStorage = false
-export let success = false
+export let success = false //deprecated
 
 let form = {}
 
@@ -17,6 +17,11 @@ $: success && resetForm(form)
 
 const resetForm = (form) => {
   form.reset()
+  sessionStorage.removeItem(id)
+}
+
+const resetSelf = (event) => {
+  event.target.reset()
   sessionStorage.removeItem(id)
 }
 
@@ -66,6 +71,13 @@ const listenForBlurOnForm = (form) => {
 }
 </style>
 
-<form bind:this={form} {id} class="w-100 {$$props.class}" on:submit|preventDefault autocomplete="off">
+<form
+  bind:this={form}
+  on:reset={resetSelf}
+  {id}
+  class="w-100 {$$props.class}"
+  on:submit|preventDefault
+  autocomplete="off"
+>
   <slot />
 </form>

--- a/components/custom/Form/Form.svelte
+++ b/components/custom/Form/Form.svelte
@@ -4,7 +4,12 @@ import { generateRandomID } from '../../../random'
 
 export let id = generateRandomID('form-')
 export let saveToLocalStorage = false
-export let success = false //deprecated
+/**
+ * @deprecated The 'success' prop has been deprecated in favor of using
+ * 'event.target.reset' on the form's submit event.
+ * Please use 'event.target.reset' instead.
+ */
+export let success = false
 
 let form = {}
 

--- a/components/custom/Form/Form.svelte
+++ b/components/custom/Form/Form.svelte
@@ -22,7 +22,7 @@ $: success && resetForm(form)
 
 const resetForm = (form) => {
   console.warn(
-    '@silintl/ui-components: success prop is deprecated, use `form on:submit={(event) => event.target.reset()} instead'
+    '@silintl/ui-components: success prop is deprecated, use `Form on:submit={(event) => event.target.reset()} instead'
   )
   form.reset()
   sessionStorage.removeItem(id)

--- a/stories/Form.stories.svelte
+++ b/stories/Form.stories.svelte
@@ -8,10 +8,10 @@ const args = {
   class: '', //only works for global classes
   id: '',
   saveToLocalStorage: false,
-  success: false,
-  'on:submit': function () {
+  success: false, //deprecated
+  'on:submit': function (e) {
     alert('submitted successfully, form will now reset and remove any saved values')
-    this.success = true
+    e.target.reset()
   },
 }
 </script>


### PR DESCRIPTION
 * The 'success' prop has been deprecated in favor of using 'event.target.reset' on the form's submit event.
 * added comments and story