### PR TITLE
feat(Form): remove success

### DIFF
--- a/components/custom/Form/Form.svelte
+++ b/components/custom/Form/Form.svelte
@@ -4,12 +4,6 @@ import { generateRandomID } from '../../../random'
 
 export let id = generateRandomID('form-')
 export let saveToLocalStorage = false
-/**
- * @deprecated The 'success' prop has been deprecated in favor of using
- * 'event.target.reset' on the form's submit event.
- * Please use 'event.target.reset' instead.
- */
-export let success = false
 
 let form = {}
 
@@ -18,15 +12,6 @@ onMount(() => {
 })
 
 $: saveToLocalStorage && restoreFormValues(form)
-$: success && resetForm(form)
-
-const resetForm = (form) => {
-  console.warn(
-    '@silintl/ui-components: success prop is deprecated, use `Form on:submit={(event) => event.target.reset()}` instead'
-  )
-  form.reset()
-  sessionStorage.removeItem(id)
-}
 
 const resetSelf = (event) => {
   event.target.reset()

--- a/index.d.ts
+++ b/index.d.ts
@@ -309,7 +309,6 @@ declare module '@silintl/ui-components' {
   interface FormProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
     id?: string
     saveToLocalStorage?: boolean
-    success?: boolean
   }
   export class Form extends SvelteComponentTyped<FormProps> {}
 

--- a/stories/Form.stories.svelte
+++ b/stories/Form.stories.svelte
@@ -8,7 +8,6 @@ const args = {
   class: '', //only works for global classes
   id: '',
   saveToLocalStorage: false,
-  success: false, //deprecated
   'on:submit': function (e) {
     alert('submitted successfully, form will now reset and remove any saved values')
     e.target.reset()


### PR DESCRIPTION
## BREAKING CHANGE: remove success prop

- To reset `Form` use `on:submit` and `event.target.reset()` instead of setting `success` to `true`