### PR TITLE
improve types

### DIFF
--- a/components/mdc/Select/Select.svelte
+++ b/components/mdc/Select/Select.svelte
@@ -6,7 +6,7 @@ import { afterUpdate, createEventDispatcher, onMount } from 'svelte'
 
 export let label = 'Select'
 
-/** @type {{id, name}[]} */
+/** @type {{id: string, name: string}[]} */
 export let options = []
 export let width = '280px'
 export let disabled = false

--- a/components/mdc/TextInput/MoneyInput.svelte
+++ b/components/mdc/TextInput/MoneyInput.svelte
@@ -36,7 +36,7 @@ $: showCounter = maxlength && valueLength / maxlength > 0.85
 $: valueHasTooManyDecPlaces = getDecimalPlacesLength(internalValue) > getDecimalPlacesLength(step)
 $: valueNotDivisibleByStep =
   (internalValue && (internalValue / Number(step)).toFixed(2) % 1 !== 0) || valueHasTooManyDecPlaces
-$: internalValue = Number(value) || 0 //this causes problems with require input as 0 is a valid string
+$: internalValue = Number(value) || 0
 
 onMount(() => {
   mdcTextField = new MDCTextField(element)

--- a/components/mdc/TextInput/MoneyInput.svelte
+++ b/components/mdc/TextInput/MoneyInput.svelte
@@ -36,7 +36,7 @@ $: showCounter = maxlength && valueLength / maxlength > 0.85
 $: valueHasTooManyDecPlaces = getDecimalPlacesLength(internalValue) > getDecimalPlacesLength(step)
 $: valueNotDivisibleByStep =
   (internalValue && (internalValue / Number(step)).toFixed(2) % 1 !== 0) || valueHasTooManyDecPlaces
-$: internalValue = Number(value) || 0
+$: internalValue = Number(value) || 0 //this causes problems with require input as 0 is a valid string
 
 onMount(() => {
   mdcTextField = new MDCTextField(element)

--- a/index.d.ts
+++ b/index.d.ts
@@ -186,15 +186,15 @@ declare module '@silintl/ui-components' {
 
   interface MoneyInputProps {
     label?: string
-    value?: number
+    value?: number | string
     name?: string
     placeholder?: string
     autofocus?: boolean
     disabled?: boolean
     required?: boolean
-    minValue?: string
-    maxValue?: string
-    step?: string
+    minValue?: number | string
+    maxValue?: number | string
+    step?: number | string
     description?: string
   }
   export class MoneyInput extends SvelteComponentTyped<MoneyInputProps> {}
@@ -211,7 +211,7 @@ declare module '@silintl/ui-components' {
   }
 
   interface SelectProps {
-    options?: { name: string; id: number }[]
+    options?: { name: string; id: string }[]
     width?: string
     disabled?: boolean
     selectedID?: string

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ declare module '@silintl/ui-components' {
 
   export type actions = typeof writable<any[]>
 
-  interface ButtonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+  interface ButtonProps {
     appendIcon?: string
     disabled?: boolean
     outlined?: boolean
@@ -19,7 +19,7 @@ declare module '@silintl/ui-components' {
 
   export function isAboveTablet(): boolean
 
-  interface CardProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+  interface CardProps {
     secondary?: string
     outlined?: boolean
     color?: string
@@ -28,7 +28,7 @@ declare module '@silintl/ui-components' {
   }
   export class Card extends SvelteComponentTyped<CardProps> {}
 
-  interface CheckboxProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+  interface CheckboxProps {
     label?: string
     checked?: boolean
     disabled?: boolean
@@ -37,7 +37,7 @@ declare module '@silintl/ui-components' {
   export class Checkbox extends SvelteComponentTyped<CheckboxProps> {}
 
   //Datatable
-  interface DatatableProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+  interface DatatableProps {
     label?: string
     numberOfCheckboxes?: number
   }
@@ -47,14 +47,14 @@ declare module '@silintl/ui-components' {
     type HeaderProps = svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']>
     export class Header extends SvelteComponentTyped<HeaderProps> {}
 
-    interface DatatableCheckboxProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+    interface DatatableCheckboxProps {
       disabled?: boolean
       rowId?: string
     }
     export class Checkbox extends SvelteComponentTyped<DatatableCheckboxProps> {}
 
     export namespace Header {
-      interface ItemProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+      interface ItemProps {
         numeric?: boolean
         columnID?: string
         sortable?: boolean
@@ -67,13 +67,13 @@ declare module '@silintl/ui-components' {
     export class Data extends SvelteComponentTyped<DataProps> {}
 
     export namespace Data {
-      interface RowProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+      interface RowProps {
         clickable?: boolean
       }
       export class Row extends SvelteComponentTyped<RowProps> {}
 
       export namespace Row {
-        interface ItemProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+        interface ItemProps {
           numeric?: boolean
           colspan?: number
         }
@@ -82,7 +82,7 @@ declare module '@silintl/ui-components' {
     }
   }
 
-  interface DateInputProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+  interface DateInputProps {
     color?: string
     borderColor?: string
     errorColor?: string
@@ -104,7 +104,7 @@ declare module '@silintl/ui-components' {
       action: string
       class: string
     }
-    interface AlertProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+    interface AlertProps {
       open?: boolean
       title?: string
       titleIcon?: string
@@ -113,14 +113,14 @@ declare module '@silintl/ui-components' {
     }
     export class Alert extends SvelteComponentTyped<AlertProps> {}
 
-    interface SimpleProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+    interface SimpleProps {
       open?: boolean
       title?: string
     }
     export class Simple extends SvelteComponentTyped<SimpleProps> {}
   }
 
-  interface DrawerProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+  interface DrawerProps {
     title?: string
     subtitle?: string
     menuItems?: {
@@ -144,7 +144,7 @@ declare module '@silintl/ui-components' {
   }
   export class Drawer extends SvelteComponentTyped<DrawerProps> {}
 
-  interface FabProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+  interface FabProps {
     icon?: string
     label?: string
     mini?: boolean
@@ -155,7 +155,7 @@ declare module '@silintl/ui-components' {
   }
   export class Fab extends SvelteComponentTyped<FabProps> {}
 
-  interface IconButtonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+  interface IconButtonProps {
     ariaLabel?: string
     disabled?: boolean
     icon?: string
@@ -164,7 +164,7 @@ declare module '@silintl/ui-components' {
   }
   export class IconButton extends SvelteComponentTyped<IconButtonProps> {}
 
-  interface ListProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+  interface ListProps {
     twoLine?: boolean
     avatar?: boolean
   }
@@ -177,14 +177,14 @@ declare module '@silintl/ui-components' {
     action?: VoidFunction
     subtitle?: string
   }
-  interface MenuProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+  interface MenuProps {
     menuItems?: MenuItem[]
     menuOpen?: boolean
     currentUrl?: string
   }
   export class Menu extends SvelteComponentTyped<MenuProps> {}
 
-  interface MoneyInputProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+  interface MoneyInputProps {
     label?: string
     value?: number
     name?: string
@@ -200,17 +200,17 @@ declare module '@silintl/ui-components' {
   export class MoneyInput extends SvelteComponentTyped<MoneyInputProps> {}
 
   export namespace Progress {
-    type CircularProps = svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']>
+    type CircularProps = {}
     export class Circular extends SvelteComponentTyped<CircularProps> {}
 
-    interface LinearProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+    interface LinearProps {
       indeterminate?: boolean
       value?: number
     }
     export class Linear extends SvelteComponentTyped<LinearProps> {}
   }
 
-  interface SelectProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+  interface SelectProps {
     options?: { name: string; id: number }[]
     width?: string
     disabled?: boolean
@@ -218,35 +218,35 @@ declare module '@silintl/ui-components' {
   }
   export class Select extends SvelteComponentTyped<SelectProps> {}
 
-  interface SwitchProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+  interface SwitchProps {
     label?: string
     disabled?: boolean
     selected?: boolean
   }
   export class Switch extends SvelteComponentTyped<SwitchProps> {}
 
-  interface SnackbarProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+  interface SnackbarProps {
     // no exported members
   }
   export class Snackbar extends SvelteComponentTyped<SnackbarProps> {}
 
-  interface TabBarProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+  interface TabBarProps {
     tab?: number
   }
   export class TabBar extends SvelteComponentTyped<TabBarProps> {}
 
   export namespace TabBar {
-    interface ScrollerProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {}
+    interface ScrollerProps {}
     export class Scroller extends SvelteComponentTyped<ScrollerProps> {}
 
-    interface TabProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+    interface TabProps {
       active?: boolean
       label?: string
     }
     export class Tab extends SvelteComponentTyped<TabProps> {}
   }
 
-  interface TextAreaProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+  interface TextAreaProps {
     label?: string
     value?: string
     name?: string
@@ -260,7 +260,7 @@ declare module '@silintl/ui-components' {
   }
   export class TextArea extends SvelteComponentTyped<TextAreaProps> {}
 
-  interface TextFieldProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+  interface TextFieldProps {
     label?: string
     value?: string
     name?: string
@@ -273,7 +273,7 @@ declare module '@silintl/ui-components' {
   }
   export class TextField extends SvelteComponentTyped<TextFieldProps> {}
 
-  interface TooltipProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+  interface TooltipProps {
     tooltipID?: string
     positionX?: 'start' | 'center' | 'end'
     positionY?: 'above' | 'below'
@@ -281,13 +281,13 @@ declare module '@silintl/ui-components' {
   export class Tooltip extends SvelteComponentTyped<TooltipProps> {}
 
   export namespace Tooltip {
-    interface TooltipWrapperProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+    interface TooltipWrapperProps {
       ariaDescribedBy?: string
     }
     export class Wrapper extends SvelteComponentTyped<TooltipWrapperProps> {}
   }
 
-  interface TopAppBarProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+  interface TopAppBarProps {
     bgColorIsVariant?: boolean
     dense?: boolean
     fixed?: boolean
@@ -295,7 +295,7 @@ declare module '@silintl/ui-components' {
   }
   export class TopAppBar extends SvelteComponentTyped<TopAppBarProps> {}
 
-  interface BadgeProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+  interface BadgeProps {
     color?: string
     borderRadius?: string
     padding?: string
@@ -303,7 +303,7 @@ declare module '@silintl/ui-components' {
   }
   export class Badge extends SvelteComponentTyped<BadgeProps> {}
 
-  interface CustomCardProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+  interface CustomCardProps {
     src?: string
     alt?: string
     title?: string
@@ -314,7 +314,7 @@ declare module '@silintl/ui-components' {
   }
   export class CustomCard extends SvelteComponentTyped<CustomCardProps> {}
 
-  interface FileDropAreaProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+  interface FileDropAreaProps {
     raised?: boolean
     outlined?: boolean
     mimeType?: string
@@ -322,14 +322,14 @@ declare module '@silintl/ui-components' {
   }
   export class FileDropArea extends SvelteComponentTyped<FileDropAreaProps> {}
 
-  interface FormProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+  interface FormProps {
     id?: string
     saveToLocalStorage?: boolean
     success?: boolean
   }
   export class Form extends SvelteComponentTyped<FormProps> {}
 
-  interface PageProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+  interface PageProps {
     loading?: boolean
     title?: string
     layout?: string
@@ -338,14 +338,14 @@ declare module '@silintl/ui-components' {
   }
   export class Page extends SvelteComponentTyped<PageProps> {}
 
-  interface StaticChipProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+  interface StaticChipProps {
     bgColor?: string
   }
   export class StaticChip extends SvelteComponentTyped<StaticChipProps> {}
 
   export function setNotice(label: string, action?: string, callback?: Function): void
 
-  interface SearchableSelectProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+  interface SearchableSelectProps {
     choice?: string
     disabled?: boolean
     maxlength?: string
@@ -359,13 +359,13 @@ declare module '@silintl/ui-components' {
 
   type steps = 'title' | 'content' | 'left' | 'right' | 'previous' | 'next' | 'target'
 
-  interface TourProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
+  interface TourProps {
     steps?: { [key in steps]: string | number }[]
     data?: { [key: string]: string }
   }
   export class Tour extends SvelteComponentTyped<TourProps> {}
 }
 
-module '@silintl/ui-components/random' {
+declare module '@silintl/ui-components/random' {
   export function generateRandomID(prefix?: string): string
 }


### PR DESCRIPTION
- remove deprecated svelte types from index.d.ts
- change Select (options) type
- change MoneyInput (value, minValue, maxValue, step) types

Regarding the deprecation:
https://github.com/sveltejs/language-tools/blob/master/docs/preprocessors/typescript.md#im-getting-deprecation-warnings-for-sveltejsx--i-want-to-migrate-to-the-new-typings