### PR TITLE
add config for note generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,12 @@
         },
         "presetConfig": {
           "types": [
-            {"type": "feat", "section": "Added"},
+            {"type": "add", "section": "Added"},
             {"type": "fix", "section": "Fixed"},
+            {"type": "change", "section": "Changed"},
+            {"type": "deprecate", "section": "Deprecated"},
+            {"type": "remove", "section": "Removed"},
+            {"type": "security", "section": "Security"},
             {"type": "chore", "hidden": true},
             {"type": "docs", "hidden": true},
             {"type": "style", "hidden": true},

--- a/package.json
+++ b/package.json
@@ -17,7 +17,23 @@
     ],
     "plugins": [
       "@semantic-release/commit-analyzer",
-      "@semantic-release/release-notes-generator",
+      ["@semantic-release/release-notes-generator", {
+        "preset": "conventionalcommits",
+        "parserOpts": {
+          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
+        },
+        "presetConfig": {
+          "types": [
+            {"type": "feat", "section": "Added"},
+            {"type": "fix", "section": "Fixed"},
+            {"type": "chore", "hidden": true},
+            {"type": "docs", "hidden": true},
+            {"type": "style", "hidden": true},
+            {"type": "refactor", "hidden": true},
+            {"type": "perf", "hidden": true},
+            {"type": "test", "hidden": true}
+        ]}
+      }],
       "@semantic-release/changelog",
       "@semantic-release/npm",
       "@semantic-release/git",


### PR DESCRIPTION
## Changed
- change notes-generator config to allow following [this](https://keepachangelog.com/en/1.1.0/) format

Notes: see [this](https://github.com/semantic-release/release-notes-generator/issues/403)  for an example