### PR TITLE
Add dry command and add semantic release plugins config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,462 @@
+## [10.0.1](https://github.com/silinternational/ui-components/compare/v10.0.0...v10.0.1) (2023-03-23)
+
+
+### Bug Fixes
+
+* **exports:** fix broken DateInput export ([d841278](https://github.com/silinternational/ui-components/commit/d84127837248d2581b424b2fa1f36ce4f4f5f11a))
+
+# [10.0.0](https://github.com/silinternational/ui-components/compare/v9.1.1...v10.0.0) (2023-03-23)
+
+
+### Bug Fixes
+
+* **types:** fix Select and MoneyInput types ([f2c6f73](https://github.com/silinternational/ui-components/commit/f2c6f73b289d0277b99a5e51cba8778fbd49ddd8))
+* **types:** JSX.HTMLAttributes is deprecated ([f8c593b](https://github.com/silinternational/ui-components/commit/f8c593b91528ecf47c5fffd8652bd5bc357b70f3))
+
+
+### Features
+
+* **components:** Add DateInput components ([a83dc70](https://github.com/silinternational/ui-components/commit/a83dc7079d70a26fa1b2800b0fb909719e52ae8d))
+* **Form:** remove success ([5f3537c](https://github.com/silinternational/ui-components/commit/5f3537c6fa8a41891d1f36a1f5ac3a697bf9fdbc))
+
+
+### BREAKING CHANGES
+
+* **Form:** remove success prop
+
+To reset `Form` use `on:submit` and `event.target.reset()` instead of setting `success` to `true`
+
+## [9.1.1](https://github.com/silinternational/ui-components/compare/v9.1.0...v9.1.1) (2023-02-22)
+
+
+### Bug Fixes
+
+* **TextArea:** fix text overlapping with counter ([c0bb58e](https://github.com/silinternational/ui-components/commit/c0bb58ef45a8d8ec83bf13bf16f89fedd0442e82))
+
+# [9.1.0](https://github.com/silinternational/ui-components/compare/v9.0.0...v9.1.0) (2023-02-22)
+
+
+### Features
+
+* **Components:** add target prop to Button, Fab, and IconButton ([d0e92bc](https://github.com/silinternational/ui-components/commit/d0e92bc6b052ad20ca2379dd26cfde2e7aff0f55))
+
+# [9.0.0](https://github.com/silinternational/ui-components/compare/v8.1.0...v9.0.0) (2023-02-08)
+
+
+### Bug Fixes
+
+* **Menu:** fix ssr for Menu using window ([e4b0b03](https://github.com/silinternational/ui-components/commit/e4b0b03fc6f2f9c9587008f826b5d6b3cdc0343f))
+
+
+### Features
+
+* **Menu:** remove focus of menuItem based on path. Add currentUrl story ([b0aca32](https://github.com/silinternational/ui-components/commit/b0aca3233d4c0aa0bbfa1df1830da44ff6ef72d9))
+* **Menu:** remove window & add currentUrl to props ([1e982ad](https://github.com/silinternational/ui-components/commit/1e982ade89b81e8a5a8e89e7c880e9e6d7a0efd3))
+
+
+### BREAKING CHANGES
+
+* **Menu:** remove checking of current path to focus menu item
+
+# [8.1.0](https://github.com/silinternational/ui-components/compare/v8.0.1...v8.1.0) (2022-12-12)
+
+
+### Features
+
+* **Form:** deprecate success and listen for reset to clear local storage ([38fad25](https://github.com/silinternational/ui-components/commit/38fad257bbb3056ea9132ba6f370d8d724d841fe))
+
+## [8.0.1](https://github.com/silinternational/ui-components/compare/v8.0.0...v8.0.1) (2022-12-03)
+
+
+### Bug Fixes
+
+* **components:** resolve A11y warning in that show up in rollup-plugin-svelte ([42229e2](https://github.com/silinternational/ui-components/commit/42229e2a047cf71ce526eb0db582757a845f0b7e))
+
+# [8.0.0](https://github.com/silinternational/ui-components/compare/v7.0.0...v8.0.0) (2022-12-01)
+
+
+### Bug Fixes
+
+* **peerDependencies:** update material-components-web and sass to match devDependencies. Fixes an npm error for consumers using material and sass. ([7d929fd](https://github.com/silinternational/ui-components/commit/7d929fd82f9f08983c167c6595e4aaaf0b58215e))
+
+
+### buid
+
+* **peerDependencies:** update peerDependencies ([a524f48](https://github.com/silinternational/ui-components/commit/a524f4845e85e05c379b24593ca49312d6abebef))
+
+
+### BREAKING CHANGES
+
+* **peerDependencies:** update peer deps
+
+Change material-components-web to 14 and sass to 1.55. If installed in your project you can now update them to these versions without an error or warning.
+
+# [7.0.0](https://github.com/silinternational/ui-components/compare/v6.7.0...v7.0.0) (2022-11-07)
+
+
+### Build System
+
+* **dependencies:** update multiple deps ([4553e7f](https://github.com/silinternational/ui-components/commit/4553e7fcbe97003fa776bacd5ae2f17c5700f9ad))
+
+
+### Features
+
+* **Form:** change Form children top margin ([0ca845f](https://github.com/silinternational/ui-components/commit/0ca845fb8ec115d25d91dec6caa6b01e2052e6f1))
+
+
+### BREAKING CHANGES
+
+* **dependencies:** update material-components-web to 15 adn sass to 1.55
+* **Form:** Form children will now have 1rem instead of 2rem
+
+# [6.7.0](https://github.com/silinternational/ui-components/compare/v6.6.0...v6.7.0) (2022-10-05)
+
+
+### Bug Fixes
+
+* **Form:** don't remove storage when restoring form values ([44ba3a9](https://github.com/silinternational/ui-components/commit/44ba3a9e2834f6687115441b05a1b87dd688d8a2))
+
+
+### Features
+
+* **Form:** add success prop so Form can remove stored values internally ([8aedd72](https://github.com/silinternational/ui-components/commit/8aedd726d267ce5ce806a8f82b2bd4331f39da96))
+
+# [6.6.0](https://github.com/silinternational/ui-components/compare/v6.5.0...v6.6.0) (2022-10-04)
+
+
+### Features
+
+* **components:** add name prop to MoneyInput, TextArea and TextField ([142b27e](https://github.com/silinternational/ui-components/commit/142b27e41751e635a4ef02745074c619fde10571))
+* **Form:** add id and saveToLocalStorage props to Form ([8216ae1](https://github.com/silinternational/ui-components/commit/8216ae10e82834ab7f3b1f0a775c12172daa171c))
+
+# [6.5.0](https://github.com/silinternational/ui-components/compare/v6.4.2...v6.5.0) (2022-09-26)
+
+
+### Features
+
+* **SearchableSelect:** add required prop ([053af32](https://github.com/silinternational/ui-components/commit/053af32385578630d8253f5feee9cf5097baa2ab))
+
+## [6.4.2](https://github.com/silinternational/ui-components/compare/v6.4.1...v6.4.2) (2022-08-24)
+
+
+### Bug Fixes
+
+* **types:** fix Scroller type warning ([d867aa0](https://github.com/silinternational/ui-components/commit/d867aa0c95bc63fbd23172c61c44ab6840cc8762))
+
+## [6.4.1](https://github.com/silinternational/ui-components/compare/v6.4.0...v6.4.1) (2022-08-24)
+
+
+### Bug Fixes
+
+* **types:** Add Scroller and Tab to TabBar type ([dd08278](https://github.com/silinternational/ui-components/commit/dd0827884c38da7137c4831882f533e1269c1df1))
+
+# [6.4.0](https://github.com/silinternational/ui-components/compare/v6.3.0...v6.4.0) (2022-08-18)
+
+
+### Features
+
+* **components:** add type support ([c2abfbc](https://github.com/silinternational/ui-components/commit/c2abfbc22f37e9ac9c724fdf81d237a204d6c9fa))
+
+# [6.3.0](https://github.com/silinternational/ui-components/compare/v6.2.0...v6.3.0) (2022-07-26)
+
+
+### Features
+
+* **components:** Add FileDropArea ([475fbd9](https://github.com/silinternational/ui-components/commit/475fbd9787e1ca49e447535f5097fc065d3c39b4))
+
+# [6.2.0](https://github.com/silinternational/ui-components/compare/v6.1.1...v6.2.0) (2022-07-05)
+
+
+### Bug Fixes
+
+* **Datatable:** expose DataRow rowId as slot prop ([46aa49c](https://github.com/silinternational/ui-components/commit/46aa49c114aecf241a2fb91745986c17e76528a8))
+* **Datatable:** fix exception when using checkbox ([f4d3433](https://github.com/silinternational/ui-components/commit/f4d34338c9b3c5fb757eaee12a44707f89a8203f))
+
+
+### Features
+
+* **components:** add DatatableCheckbox and DatatableCheckboxHeader ([5c2da10](https://github.com/silinternational/ui-components/commit/5c2da10e8fe7e53b5b1e31531887c98dfa6a9560))
+* **Datatable:** add numberOfCheckboxes to register new Checkboxes ([01aa5d0](https://github.com/silinternational/ui-components/commit/01aa5d0e146216aa88d99b1a1dcd32f0e30f1881))
+
+## [6.1.1](https://github.com/silinternational/ui-components/compare/v6.1.0...v6.1.1) (2022-06-23)
+
+
+### Bug Fixes
+
+* **index.mjs:** Switch was not exported ([b3bb6ac](https://github.com/silinternational/ui-components/commit/b3bb6ac203c84eaed6b52dbe24a76042a1883f72))
+
+# [6.1.0](https://github.com/silinternational/ui-components/compare/v6.0.1...v6.1.0) (2022-06-16)
+
+
+### Features
+
+* **components:** add Switch story ([8889e11](https://github.com/silinternational/ui-components/commit/8889e1197edad4ddaeae767a2508533f5cb220b4))
+
+## [6.0.1](https://github.com/silinternational/ui-components/compare/v6.0.0...v6.0.1) (2022-05-23)
+
+
+### Bug Fixes
+
+* **Drawer:** fix find and replace typo ([11943d3](https://github.com/silinternational/ui-components/commit/11943d33bfd41a2e94f37afe58a825a63d7e29d0))
+
+# [6.0.0](https://github.com/silinternational/ui-components/compare/v5.1.1...v6.0.0) (2022-04-28)
+
+
+### Bug Fixes
+
+* **Dialog:** fix Alert titleIcon position ([be8bac7](https://github.com/silinternational/ui-components/commit/be8bac77c3b69cf82859bb2b5247bce168b7784f))
+* **MoneyInput:** fix 1x10e-n not being caught by step ([84a6cef](https://github.com/silinternational/ui-components/commit/84a6cefac85b34865283b4880c6ece0267ad41c6))
+* **Select:** fix floating label color ([12d120d](https://github.com/silinternational/ui-components/commit/12d120da7f8095a55de976a1a391260777c19cba))
+
+
+### Build System
+
+* **deps:** update material-components-web and sass ([6e44b76](https://github.com/silinternational/ui-components/commit/6e44b7644e28083646bcaaedc9dbfedaf0f978b4))
+
+
+### Features
+
+* **components:** add SearchableSelect ([2de1351](https://github.com/silinternational/ui-components/commit/2de13515ac43d56a63ee0ed3092b01a146a689c4))
+* **Diaolog.Alert:** expose titleIcon color to --mdc-theme-icon-color ([f8c9ad0](https://github.com/silinternational/ui-components/commit/f8c9ad0c6c82872896baf6898488ee56aab901cb))
+
+
+### BREAKING CHANGES
+
+* **deps:** Consumer must install sass@1.50.x and material-components-web@13. See https://github.com/material-components/material-components-web/blob/master/CHANGELOG.md
+
+## [5.1.1](https://github.com/silinternational/ui-components/compare/v5.1.0...v5.1.1) (2022-04-04)
+
+
+### Bug Fixes
+
+* **imports:** fix circular dependency warnings ([81ca49f](https://github.com/silinternational/ui-components/commit/81ca49f171988be3882c78404d6a2b77f6c3c2d4))
+* **MoneyInput:** fix valueNotDivisibleByStep for most values ([d38c333](https://github.com/silinternational/ui-components/commit/d38c3335a42d04e764404718029ace1647212a21))
+
+# [5.1.0](https://github.com/silinternational/ui-components/compare/v5.0.1...v5.1.0) (2022-03-12)
+
+
+### Features
+
+* **Tooltip:** add class prop to Wrapper ([38a9669](https://github.com/silinternational/ui-components/commit/38a9669cabc56804e78fc0a8869e12a1f53fb587))
+
+## [5.0.1](https://github.com/silinternational/ui-components/compare/v5.0.0...v5.0.1) (2022-03-04)
+
+
+### Bug Fixes
+
+* **MoneyInput:** fix step bug when 2.01 is entered ([10b8f9c](https://github.com/silinternational/ui-components/commit/10b8f9c79d03640ebf3ce4f161c8a105be042f7d))
+
+# [5.0.0](https://github.com/silinternational/ui-components/compare/v4.1.0...v5.0.0) (2022-02-24)
+
+
+### Bug Fixes
+
+* **Drawer:** use element to listen for closed ([111d0e4](https://github.com/silinternational/ui-components/commit/111d0e463d2525cd466960513717c13f3913ac7d))
+* **icons:** icons not loading in sveltekit SSR ([bfa8e19](https://github.com/silinternational/ui-components/commit/bfa8e19c72ab9b522c30cb7daa410a889991f942))
+* **index:** use index.mjs as entry point ([f4aec84](https://github.com/silinternational/ui-components/commit/f4aec84275a4015c1a2d913ef5de618f5a35021c))
+
+
+### Features
+
+* **icons:** remove autoloading material icons ([e3c0483](https://github.com/silinternational/ui-components/commit/e3c0483c0a69a6859146c03834f07233d9b09edd))
+
+
+### BREAKING CHANGES
+
+* **icons:** consumer now imports icons. see README.
+
+# [4.1.0](https://github.com/silinternational/ui-components/compare/v4.0.0...v4.1.0) (2022-02-21)
+
+
+### Features
+
+* **Dialog.Alert:** add titleIcon prop ([13a9c41](https://github.com/silinternational/ui-components/commit/13a9c41280de3cce064d8a94db1a10be8268c5f1))
+* **Dialog.Alert:** allow modal to close itself ([d4df8e8](https://github.com/silinternational/ui-components/commit/d4df8e826f813f9c9a148fc5bfe1966466cf3822))
+* **Menu:** add subtitle to menuItems prop as splitters ([b23fab6](https://github.com/silinternational/ui-components/commit/b23fab6e349ad9c1fd8a397ee6cf54463db6d0b0))
+
+# [4.0.0](https://github.com/silinternational/ui-components/compare/v3.12.1...v4.0.0) (2022-02-17)
+
+
+### Bug Fixes
+
+* **Tour:** resolve a11y warnings ([f4e3132](https://github.com/silinternational/ui-components/commit/f4e31324311ec3ec1b97678c9769168d045ec7f5))
+
+
+### Features
+
+* **Drawer:** add currentUrl prop and remove roxi ([c38dfac](https://github.com/silinternational/ui-components/commit/c38dfac0f96e1c9ad243244c00f9db9d4353b327))
+* **Drawer:** remove beforeUrlChange ([2247b8c](https://github.com/silinternational/ui-components/commit/2247b8c4bfb2164605a9159cbf3ed75e1aff1471))
+* **IconButton:** add url and disabled props ([fba3e6b](https://github.com/silinternational/ui-components/commit/fba3e6bc13ab69fc199b35cda09b06206747669a))
+
+
+### BREAKING CHANGES
+
+* **Drawer:** The consumer must update the currentUrl as a prop
+
+## [3.12.1](https://github.com/silinternational/ui-components/compare/v3.12.0...v3.12.1) (2022-02-17)
+
+
+### Bug Fixes
+
+* **deps:** add sass to peerDependencies ([08b09de](https://github.com/silinternational/ui-components/commit/08b09de76f7c281cf684f5f7a9da3544aaefffee))
+
+# [3.12.0](https://github.com/silinternational/ui-components/compare/v3.11.0...v3.12.0) (2022-02-14)
+
+
+### Features
+
+* **TextInput:** add description property ([a215a58](https://github.com/silinternational/ui-components/commit/a215a58e37d3bf57f2fdfc642c02adf5371dcb12))
+* **TextInput:** add description story ([a75efd6](https://github.com/silinternational/ui-components/commit/a75efd6e296aebdd4ba4514481ad07f5a688d8e1))
+* **utils:** add quarter/half margin & padding ([feeb42f](https://github.com/silinternational/ui-components/commit/feeb42f96d1d078cd914c61be41d196216fdc124))
+
+# [3.11.0](https://github.com/silinternational/ui-components/compare/v3.10.6...v3.11.0) (2022-02-10)
+
+
+### Features
+
+* **Button:** expose radius and outline color ([90b7fd1](https://github.com/silinternational/ui-components/commit/90b7fd1c0db231f605599a8fe493a8dbd0bd27b1))
+* **TextField:** expose radius var to consumer ([3757b15](https://github.com/silinternational/ui-components/commit/3757b15380d13655ed593e365e53e1473c677660))
+
+## [3.10.6](https://github.com/silinternational/ui-components/compare/v3.10.5...v3.10.6) (2022-01-13)
+
+
+### Bug Fixes
+
+* **Drawer:** fix a11y warning ([3394ec3](https://github.com/silinternational/ui-components/commit/3394ec34e0fa535b761932d3be3b90dd574e4f73))
+
+## [3.10.5](https://github.com/silinternational/ui-components/compare/v3.10.4...v3.10.5) (2022-01-06)
+
+
+### Bug Fixes
+
+* **DataTable:** sort button should be on left side of numeric HeaderItem ([4376c56](https://github.com/silinternational/ui-components/commit/4376c567b53178ff868b242ac183b8bc2cd42c7f))
+
+## [3.10.4](https://github.com/silinternational/ui-components/compare/v3.10.3...v3.10.4) (2022-01-03)
+
+
+### Bug Fixes
+
+* **TextInputs:** fix circular dependencies ([cb73f9c](https://github.com/silinternational/ui-components/commit/cb73f9cebb1cb97ea054c599627c91f724ffaf41))
+
+## [3.10.3](https://github.com/silinternational/ui-components/compare/v3.10.2...v3.10.3) (2021-12-22)
+
+
+### Bug Fixes
+
+* **MoneyInput:** fix value two way binding ([7bbf8a5](https://github.com/silinternational/ui-components/commit/7bbf8a529b3abb04f5e548c6ff322823610445b1))
+* **TextInput:** fix offsetWidth error on undefined ([5d2ca72](https://github.com/silinternational/ui-components/commit/5d2ca72c73470a55351a397ef480451f0ef257d7))
+
+## [3.10.2](https://github.com/silinternational/ui-components/compare/v3.10.1...v3.10.2) (2021-12-22)
+
+
+### Bug Fixes
+
+* **MoneyInput:** forgot to add MoneyInput to index ([fceb8e0](https://github.com/silinternational/ui-components/commit/fceb8e093461123f000c32905b26756635263b23))
+* **Textinput:** fix error on reading 'remove' ([1a209f9](https://github.com/silinternational/ui-components/commit/1a209f976abadaf9e5e8f6e543648278c75c1937))
+
+## [3.10.1](https://github.com/silinternational/ui-components/compare/v3.10.0...v3.10.1) (2021-12-21)
+
+
+### Bug Fixes
+
+* **MoneyInput:** fix MoneyInput staying red ([2adc91c](https://github.com/silinternational/ui-components/commit/2adc91c73076af2a99c324a0b3b20b5c645ac343))
+
+# [3.10.0](https://github.com/silinternational/ui-components/compare/v3.9.0...v3.10.0) (2021-12-21)
+
+
+### Bug Fixes
+
+* **MoneyInput:** fix label color for required ([dc9c3ba](https://github.com/silinternational/ui-components/commit/dc9c3ba6dcb273906974252eaf041f9bdcdf4976))
+* **MoneyInput:** remove error state on:focus for required ([3e6c2f5](https://github.com/silinternational/ui-components/commit/3e6c2f5f70ce3b26fb46d0dbd32bb16e566ce6f8))
+* **TextInput:** label not turning red for required ([b9d924a](https://github.com/silinternational/ui-components/commit/b9d924aaf13d7879c7a8bc96c40a0f54362e277e))
+* **TextInput:** Show *Required initially and change backup color ([b84548a](https://github.com/silinternational/ui-components/commit/b84548aed92d97fc0d3ace431866f2101acee5fd))
+* **TextInput:** show appropriate icons/colors ([925a6ac](https://github.com/silinternational/ui-components/commit/925a6accd712b09c7abb29fda3e042b6e5785bf7))
+
+
+### Features
+
+* **TextArea:** add required prop and story ([6045274](https://github.com/silinternational/ui-components/commit/60452747c39381f07efae67e9caf36e29ebdbd13))
+
+# [3.9.0](https://github.com/silinternational/ui-components/compare/v3.8.0...v3.9.0) (2021-12-20)
+
+
+### Bug Fixes
+
+* **TextArea:** typo and counter rendering "524288" ([94992b6](https://github.com/silinternational/ui-components/commit/94992b6485bd3931317ea3be9ee23d929ab28ca8))
+* **TextField:** *Required was hidden until focused ([d320bca](https://github.com/silinternational/ui-components/commit/d320bca567cf5af0c390eb8d0b15cc4eb22ecf93))
+* **TextField:** allow value to be > maxlengh ([c09def6](https://github.com/silinternational/ui-components/commit/c09def60f1a58948691668bcaf3ae54311cbc936))
+
+
+### Features
+
+* **components:** add MoneyInput and story ([021d291](https://github.com/silinternational/ui-components/commit/021d2912e355de327153983f3c961624d5bbd7e6))
+* **MoneyInput:** add counter & icon on maxlength ([d22bda8](https://github.com/silinternational/ui-components/commit/d22bda8eb9889ec56c1b608ee08ffbaedf8c0f02))
+* **MoneyInput:** add maxlength warning, fix width ([6ce6458](https://github.com/silinternational/ui-components/commit/6ce6458111a987d4fa7f53d3f33a0bfb4500972b))
+* **MoneyInput:** add step, maxValue, minValue and helper text ([db5de95](https://github.com/silinternational/ui-components/commit/db5de959513fd1542fbb759a3f5c093efa9402af))
+* **TextArea:** allow value > maxlength & add warning ([6151b60](https://github.com/silinternational/ui-components/commit/6151b60883aa9e7354eb8bd42d567aa2eea1b00f))
+* **TextArea:** make outline red on maxlength ([70d3920](https://github.com/silinternational/ui-components/commit/70d3920def943c3fea47a9b1cde7d113118793c2))
+* **TextField:** add character counter ([eba6321](https://github.com/silinternational/ui-components/commit/eba6321dbd260d9e06deb88536706e29dbd406d1))
+* **TextField:** Add icon prop ([568f659](https://github.com/silinternational/ui-components/commit/568f6596feda14d1617a890e4ecd5ce6618837ce))
+* **TextField:** add maxlength warning, fix width ([67b145a](https://github.com/silinternational/ui-components/commit/67b145affb014b5c1ac978201be4bccd060490bd))
+* **TextField:** make outline red on maxlength ([44b52dc](https://github.com/silinternational/ui-components/commit/44b52dcca5df813c11a1429541a4dd1a4ca35bd8))
+* **textinput:** use error color on counter and label for maxlength ([364ddba](https://github.com/silinternational/ui-components/commit/364ddbacfab8cab8c1fc388f14ba71fa50f6070c))
+* **utils:** add min, max, height and width utils ([5d737f3](https://github.com/silinternational/ui-components/commit/5d737f3d6200dce6e81f65be42cdbba9f5f584e3))
+* **utils:** change margin and padding up to 50px ([fa3aa85](https://github.com/silinternational/ui-components/commit/fa3aa85d1099b43be47669d19135dfc363345736))
+
+# [3.8.0](https://github.com/silinternational/ui-components/compare/v3.7.0...v3.8.0) (2021-12-13)
+
+
+### Features
+
+* **Drawer:** use var to set main content height ([79c4a51](https://github.com/silinternational/ui-components/commit/79c4a51e77ffc2596f146b234fb959d910bdd882))
+* **Page:** unset height and add $$props.class ([d292cf1](https://github.com/silinternational/ui-components/commit/d292cf13b1f091b39eb607fdb23cdd5fd69c8419))
+* **TextField:** add required field option ([2b594ae](https://github.com/silinternational/ui-components/commit/2b594ae8c0fde5ba509270d17be962484a4a89ca))
+
+# [3.7.0](https://github.com/silinternational/ui-components/compare/v3.6.0...v3.7.0) (2021-11-22)
+
+
+### Features
+
+* **Drawer:** add url pattern matching ([4ad5821](https://github.com/silinternational/ui-components/commit/4ad5821d72a6eee282c0f3d2cf8529b1a54e9531))
+
+# [3.6.0](https://github.com/silinternational/ui-components/compare/v3.5.0...v3.6.0) (2021-11-05)
+
+
+### Features
+
+* **TextField:** add keydown, keypress, and keyup events ([da1b1bd](https://github.com/silinternational/ui-components/commit/da1b1bd46782514b23a795bad12d11b049057be8))
+
+# [3.5.0](https://github.com/silinternational/ui-components/compare/v3.4.0...v3.5.0) (2021-10-19)
+
+
+### Features
+
+* **Drawer:** Add optional content slot above menu in Drawer ([6aa7ddb](https://github.com/silinternational/ui-components/commit/6aa7ddb98b11a97e19fd9fb0139ab1f9d9ee22bd))
+
+# [3.4.0](https://github.com/silinternational/ui-components/compare/v3.3.0...v3.4.0) (2021-10-18)
+
+
+### Bug Fixes
+
+* **Datatable:** Fix text-alignment in numeric Datatable cells ([8f733da](https://github.com/silinternational/ui-components/commit/8f733da8c46a059bfd7a98c40d82f94f9ce30366))
+
+
+### Features
+
+* **Drawer:** Add support for tooltips on menu items ([27cd6f9](https://github.com/silinternational/ui-components/commit/27cd6f92e5de773054989cabbc3b2a272f59a801))
+
+# [3.3.0](https://github.com/silinternational/ui-components/compare/v3.2.0...v3.3.0) (2021-10-13)
+
+
+### Bug Fixes
+
+* **TextInput:** remove Noto Sans ([3591a21](https://github.com/silinternational/ui-components/commit/3591a214ae96b722b0c1945676fe2a5df1e7ef74))
+
+
+### Features
+
+* **Menu:** add support for actions in MenuItems ([ce271f2](https://github.com/silinternational/ui-components/commit/ce271f22d444bfc6bb9e5e73605eb0079eca76c9))
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@silintl/ui-components",
-  "version": "3.2.0",
+  "version": "10.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@silintl/ui-components",
-      "version": "3.2.0",
+      "version": "10.0.1",
       "license": "MIT",
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.2",
@@ -21,6 +21,7 @@
         "@storybook/manager-webpack5": "^6.5.16",
         "@storybook/preset-scss": "^1.0.3",
         "@storybook/svelte": "^6.5.16",
+        "conventional-changelog": "^3.1.25",
         "css-loader": "^6.7.3",
         "material-components-web": "^14.0.0",
         "prettier": "^2.8.5",
@@ -2008,6 +2009,15 @@
       "dev": true,
       "optional": true,
       "peer": true
+    },
+    "node_modules/@hutson/parse-repository-url": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz",
+      "integrity": "sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -9711,6 +9721,12 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/add-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
+      "integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
+      "dev": true
+    },
     "node_modules/address": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/address/-/address-1.2.2.tgz",
@@ -11888,6 +11904,28 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/conventional-changelog": {
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-3.1.25.tgz",
+      "integrity": "sha512-ryhi3fd1mKf3fSjbLXOfK2D06YwKNic1nC9mWqybBHdObPd8KJ2vjaXZfYj1U23t+V8T8n0d7gwnc9XbIdFbyQ==",
+      "dev": true,
+      "dependencies": {
+        "conventional-changelog-angular": "^5.0.12",
+        "conventional-changelog-atom": "^2.0.8",
+        "conventional-changelog-codemirror": "^2.0.8",
+        "conventional-changelog-conventionalcommits": "^4.5.0",
+        "conventional-changelog-core": "^4.2.1",
+        "conventional-changelog-ember": "^2.0.9",
+        "conventional-changelog-eslint": "^3.0.9",
+        "conventional-changelog-express": "^2.0.6",
+        "conventional-changelog-jquery": "^3.0.11",
+        "conventional-changelog-jshint": "^2.0.9",
+        "conventional-changelog-preset-loader": "^2.3.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/conventional-changelog-angular": {
       "version": "5.0.13",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
@@ -11897,6 +11935,323 @@
         "compare-func": "^2.0.0",
         "q": "^1.5.1"
       },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-atom": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-2.0.8.tgz",
+      "integrity": "sha512-xo6v46icsFTK3bb7dY/8m2qvc8sZemRgdqLb/bjpBsH2UyOS8rKNTgcb5025Hri6IpANPApbXMg15QLb1LJpBw==",
+      "dev": true,
+      "dependencies": {
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-codemirror": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-2.0.8.tgz",
+      "integrity": "sha512-z5DAsn3uj1Vfp7po3gpt2Boc+Bdwmw2++ZHa5Ak9k0UKsYAO5mH1UBTN0qSCuJZREIhX6WU4E1p3IW2oRCNzQw==",
+      "dev": true,
+      "dependencies": {
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.3.tgz",
+      "integrity": "sha512-LTTQV4fwOM4oLPad317V/QNQ1FY4Hju5qeBIM1uTHbrnCE+Eg4CdRZ3gO2pUeR+tzWdp80M2j3qFFEDWVqOV4g==",
+      "dev": true,
+      "dependencies": {
+        "compare-func": "^2.0.0",
+        "lodash": "^4.17.15",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-core": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-4.2.4.tgz",
+      "integrity": "sha512-gDVS+zVJHE2v4SLc6B0sLsPiloR0ygU7HaDW14aNJE1v4SlqJPILPl/aJC7YdtRE4CybBf8gDwObBvKha8Xlyg==",
+      "dev": true,
+      "dependencies": {
+        "add-stream": "^1.0.0",
+        "conventional-changelog-writer": "^5.0.0",
+        "conventional-commits-parser": "^3.2.0",
+        "dateformat": "^3.0.0",
+        "get-pkg-repo": "^4.0.0",
+        "git-raw-commits": "^2.0.8",
+        "git-remote-origin-url": "^2.0.0",
+        "git-semver-tags": "^4.1.1",
+        "lodash": "^4.17.15",
+        "normalize-package-data": "^3.0.0",
+        "q": "^1.5.1",
+        "read-pkg": "^3.0.0",
+        "read-pkg-up": "^3.0.0",
+        "through2": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-core/node_modules/find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/conventional-changelog-core/node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-core/node_modules/locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/conventional-changelog-core/node_modules/normalize-package-data": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-core/node_modules/p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/conventional-changelog-core/node_modules/p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/conventional-changelog-core/node_modules/p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/conventional-changelog-core/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/conventional-changelog-core/node_modules/path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/conventional-changelog-core/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/conventional-changelog-core/node_modules/read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
+      "dev": true,
+      "dependencies": {
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/conventional-changelog-core/node_modules/read-pkg-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+      "integrity": "sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^2.0.0",
+        "read-pkg": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/conventional-changelog-core/node_modules/read-pkg/node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
+    },
+    "node_modules/conventional-changelog-core/node_modules/read-pkg/node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/conventional-changelog-core/node_modules/read-pkg/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/conventional-changelog-core/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-ember": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-2.0.9.tgz",
+      "integrity": "sha512-ulzIReoZEvZCBDhcNYfDIsLTHzYHc7awh+eI44ZtV5cx6LVxLlVtEmcO+2/kGIHGtw+qVabJYjdI5cJOQgXh1A==",
+      "dev": true,
+      "dependencies": {
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-eslint": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-3.0.9.tgz",
+      "integrity": "sha512-6NpUCMgU8qmWmyAMSZO5NrRd7rTgErjrm4VASam2u5jrZS0n38V7Y9CzTtLT2qwz5xEChDR4BduoWIr8TfwvXA==",
+      "dev": true,
+      "dependencies": {
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-express": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-2.0.6.tgz",
+      "integrity": "sha512-SDez2f3iVJw6V563O3pRtNwXtQaSmEfTCaTBPCqn0oG0mfkq0rX4hHBq5P7De2MncoRixrALj3u3oQsNK+Q0pQ==",
+      "dev": true,
+      "dependencies": {
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-jquery": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-3.0.11.tgz",
+      "integrity": "sha512-x8AWz5/Td55F7+o/9LQ6cQIPwrCjfJQ5Zmfqi8thwUEKHstEn4kTIofXub7plf1xvFA2TqhZlq7fy5OmV6BOMw==",
+      "dev": true,
+      "dependencies": {
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-jshint": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-2.0.9.tgz",
+      "integrity": "sha512-wMLdaIzq6TNnMHMy31hql02OEQ8nCQfExw1SE0hYL5KvU+JCTuPaDO+7JiogGT2gJAxiUGATdtYYfh+nT+6riA==",
+      "dev": true,
+      "dependencies": {
+        "compare-func": "^2.0.0",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-preset-loader": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.3.4.tgz",
+      "integrity": "sha512-GEKRWkrSAZeTq5+YjUZOYxdHq+ci4dNwHvpaBC3+ENalzFWuCWa9EZXSuZBpkr72sMdKB+1fyDV4takK1Lf58g==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -12673,6 +13028,15 @@
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
       "integrity": "sha512-NJGVKPS81XejHcLhaLJS7plab0fK3slPh11mESeeDq2W4ZI5kUKK/LRRdVDvjJseojbPB7ZwjnyOybg3Igea/A==",
       "dev": true
+    },
+    "node_modules/dargs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
+      "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/dateformat": {
       "version": "3.0.3",
@@ -15313,6 +15677,76 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/get-pkg-repo": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-4.2.1.tgz",
+      "integrity": "sha512-2+QbHjFRfGB74v/pYWjd5OhU3TDIC2Gv/YKUTk/tCvAz0pkn/Mz6P3uByuBimLOcPvN2jYdScl3xGFSrx0jEcA==",
+      "dev": true,
+      "dependencies": {
+        "@hutson/parse-repository-url": "^3.0.0",
+        "hosted-git-info": "^4.0.0",
+        "through2": "^2.0.0",
+        "yargs": "^16.2.0"
+      },
+      "bin": {
+        "get-pkg-repo": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-pkg-repo/node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/get-pkg-repo/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true
+    },
+    "node_modules/get-pkg-repo/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/get-pkg-repo/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/get-pkg-repo/node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
     "node_modules/get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
@@ -15421,6 +15855,72 @@
       "dependencies": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/git-raw-commits": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.11.tgz",
+      "integrity": "sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==",
+      "dev": true,
+      "dependencies": {
+        "dargs": "^7.0.0",
+        "lodash": "^4.17.15",
+        "meow": "^8.0.0",
+        "split2": "^3.0.0",
+        "through2": "^4.0.0"
+      },
+      "bin": {
+        "git-raw-commits": "cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/git-remote-origin-url": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
+      "integrity": "sha512-eU+GGrZgccNJcsDH5LkXR3PB9M958hxc7sbA8DFJjrv9j4L2P/eZfKhM+QD6wyzpiv+b1BpK0XrYCxkovtjSLw==",
+      "dev": true,
+      "dependencies": {
+        "gitconfiglocal": "^1.0.0",
+        "pify": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/git-remote-origin-url/node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/git-semver-tags": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-4.1.1.tgz",
+      "integrity": "sha512-OWyMt5zBe7xFs8vglMmhM9lRQzCWL3WjHtxNNfJTMngGym7pC1kh8sP6jevfydJ6LP3ZvGxfb6ABYgPUM0mtsA==",
+      "dev": true,
+      "dependencies": {
+        "meow": "^8.0.0",
+        "semver": "^6.0.0"
+      },
+      "bin": {
+        "git-semver-tags": "cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gitconfiglocal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
+      "integrity": "sha512-spLUXeTAVHxDtKsJc8FkFVgFtMdEN9qPGpL23VfSHx4fP4+Ds097IXLvymbnDH8FnmxX5Nr9bPw3A+AQ6mWEaQ==",
+      "dev": true,
+      "dependencies": {
+        "ini": "^1.3.2"
       }
     },
     "node_modules/github-slugger": {
@@ -29254,6 +29754,12 @@
       "optional": true,
       "peer": true
     },
+    "@hutson/parse-repository-url": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz",
+      "integrity": "sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==",
+      "dev": true
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -35447,6 +35953,12 @@
       "dev": true,
       "requires": {}
     },
+    "add-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
+      "integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
+      "dev": true
+    },
     "address": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/address/-/address-1.2.2.tgz",
@@ -37145,6 +37657,25 @@
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
     },
+    "conventional-changelog": {
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-3.1.25.tgz",
+      "integrity": "sha512-ryhi3fd1mKf3fSjbLXOfK2D06YwKNic1nC9mWqybBHdObPd8KJ2vjaXZfYj1U23t+V8T8n0d7gwnc9XbIdFbyQ==",
+      "dev": true,
+      "requires": {
+        "conventional-changelog-angular": "^5.0.12",
+        "conventional-changelog-atom": "^2.0.8",
+        "conventional-changelog-codemirror": "^2.0.8",
+        "conventional-changelog-conventionalcommits": "^4.5.0",
+        "conventional-changelog-core": "^4.2.1",
+        "conventional-changelog-ember": "^2.0.9",
+        "conventional-changelog-eslint": "^3.0.9",
+        "conventional-changelog-express": "^2.0.6",
+        "conventional-changelog-jquery": "^3.0.11",
+        "conventional-changelog-jshint": "^2.0.9",
+        "conventional-changelog-preset-loader": "^2.3.4"
+      }
+    },
     "conventional-changelog-angular": {
       "version": "5.0.13",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
@@ -37154,6 +37685,252 @@
         "compare-func": "^2.0.0",
         "q": "^1.5.1"
       }
+    },
+    "conventional-changelog-atom": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-2.0.8.tgz",
+      "integrity": "sha512-xo6v46icsFTK3bb7dY/8m2qvc8sZemRgdqLb/bjpBsH2UyOS8rKNTgcb5025Hri6IpANPApbXMg15QLb1LJpBw==",
+      "dev": true,
+      "requires": {
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-codemirror": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-2.0.8.tgz",
+      "integrity": "sha512-z5DAsn3uj1Vfp7po3gpt2Boc+Bdwmw2++ZHa5Ak9k0UKsYAO5mH1UBTN0qSCuJZREIhX6WU4E1p3IW2oRCNzQw==",
+      "dev": true,
+      "requires": {
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-conventionalcommits": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.3.tgz",
+      "integrity": "sha512-LTTQV4fwOM4oLPad317V/QNQ1FY4Hju5qeBIM1uTHbrnCE+Eg4CdRZ3gO2pUeR+tzWdp80M2j3qFFEDWVqOV4g==",
+      "dev": true,
+      "requires": {
+        "compare-func": "^2.0.0",
+        "lodash": "^4.17.15",
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-core": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-4.2.4.tgz",
+      "integrity": "sha512-gDVS+zVJHE2v4SLc6B0sLsPiloR0ygU7HaDW14aNJE1v4SlqJPILPl/aJC7YdtRE4CybBf8gDwObBvKha8Xlyg==",
+      "dev": true,
+      "requires": {
+        "add-stream": "^1.0.0",
+        "conventional-changelog-writer": "^5.0.0",
+        "conventional-commits-parser": "^3.2.0",
+        "dateformat": "^3.0.0",
+        "get-pkg-repo": "^4.0.0",
+        "git-raw-commits": "^2.0.8",
+        "git-remote-origin-url": "^2.0.0",
+        "git-semver-tags": "^4.1.1",
+        "lodash": "^4.17.15",
+        "normalize-package-data": "^3.0.0",
+        "q": "^1.5.1",
+        "read-pkg": "^3.0.0",
+        "read-pkg-up": "^3.0.0",
+        "through2": "^4.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "hosted-git-info": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+          "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "normalize-package-data": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+          "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^4.0.1",
+            "is-core-module": "^2.5.0",
+            "semver": "^7.3.4",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+          "dev": true
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          },
+          "dependencies": {
+            "hosted-git-info": {
+              "version": "2.8.9",
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+              "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+              "dev": true
+            },
+            "normalize-package-data": {
+              "version": "2.5.0",
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+              "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+              "dev": true,
+              "requires": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+              }
+            },
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "dev": true
+            }
+          }
+        },
+        "read-pkg-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "integrity": "sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "conventional-changelog-ember": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-2.0.9.tgz",
+      "integrity": "sha512-ulzIReoZEvZCBDhcNYfDIsLTHzYHc7awh+eI44ZtV5cx6LVxLlVtEmcO+2/kGIHGtw+qVabJYjdI5cJOQgXh1A==",
+      "dev": true,
+      "requires": {
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-eslint": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-3.0.9.tgz",
+      "integrity": "sha512-6NpUCMgU8qmWmyAMSZO5NrRd7rTgErjrm4VASam2u5jrZS0n38V7Y9CzTtLT2qwz5xEChDR4BduoWIr8TfwvXA==",
+      "dev": true,
+      "requires": {
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-express": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-2.0.6.tgz",
+      "integrity": "sha512-SDez2f3iVJw6V563O3pRtNwXtQaSmEfTCaTBPCqn0oG0mfkq0rX4hHBq5P7De2MncoRixrALj3u3oQsNK+Q0pQ==",
+      "dev": true,
+      "requires": {
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-jquery": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-3.0.11.tgz",
+      "integrity": "sha512-x8AWz5/Td55F7+o/9LQ6cQIPwrCjfJQ5Zmfqi8thwUEKHstEn4kTIofXub7plf1xvFA2TqhZlq7fy5OmV6BOMw==",
+      "dev": true,
+      "requires": {
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-jshint": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-2.0.9.tgz",
+      "integrity": "sha512-wMLdaIzq6TNnMHMy31hql02OEQ8nCQfExw1SE0hYL5KvU+JCTuPaDO+7JiogGT2gJAxiUGATdtYYfh+nT+6riA==",
+      "dev": true,
+      "requires": {
+        "compare-func": "^2.0.0",
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-preset-loader": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.3.4.tgz",
+      "integrity": "sha512-GEKRWkrSAZeTq5+YjUZOYxdHq+ci4dNwHvpaBC3+ENalzFWuCWa9EZXSuZBpkr72sMdKB+1fyDV4takK1Lf58g==",
+      "dev": true
     },
     "conventional-changelog-writer": {
       "version": "5.0.1",
@@ -37756,6 +38533,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
       "integrity": "sha512-NJGVKPS81XejHcLhaLJS7plab0fK3slPh11mESeeDq2W4ZI5kUKK/LRRdVDvjJseojbPB7ZwjnyOybg3Igea/A==",
+      "dev": true
+    },
+    "dargs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
+      "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
       "dev": true
     },
     "dateformat": {
@@ -39841,6 +40624,69 @@
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true
     },
+    "get-pkg-repo": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-4.2.1.tgz",
+      "integrity": "sha512-2+QbHjFRfGB74v/pYWjd5OhU3TDIC2Gv/YKUTk/tCvAz0pkn/Mz6P3uByuBimLOcPvN2jYdScl3xGFSrx0jEcA==",
+      "dev": true,
+      "requires": {
+        "@hutson/parse-repository-url": "^3.0.0",
+        "hosted-git-info": "^4.0.0",
+        "through2": "^2.0.0",
+        "yargs": "^16.2.0"
+      },
+      "dependencies": {
+        "hosted-git-info": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+          "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        }
+      }
+    },
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
@@ -39933,6 +40779,56 @@
             "xtend": "~4.0.1"
           }
         }
+      }
+    },
+    "git-raw-commits": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.11.tgz",
+      "integrity": "sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==",
+      "dev": true,
+      "requires": {
+        "dargs": "^7.0.0",
+        "lodash": "^4.17.15",
+        "meow": "^8.0.0",
+        "split2": "^3.0.0",
+        "through2": "^4.0.0"
+      }
+    },
+    "git-remote-origin-url": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
+      "integrity": "sha512-eU+GGrZgccNJcsDH5LkXR3PB9M958hxc7sbA8DFJjrv9j4L2P/eZfKhM+QD6wyzpiv+b1BpK0XrYCxkovtjSLw==",
+      "dev": true,
+      "requires": {
+        "gitconfiglocal": "^1.0.0",
+        "pify": "^2.3.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+          "dev": true
+        }
+      }
+    },
+    "git-semver-tags": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-4.1.1.tgz",
+      "integrity": "sha512-OWyMt5zBe7xFs8vglMmhM9lRQzCWL3WjHtxNNfJTMngGym7pC1kh8sP6jevfydJ6LP3ZvGxfb6ABYgPUM0mtsA==",
+      "dev": true,
+      "requires": {
+        "meow": "^8.0.0",
+        "semver": "^6.0.0"
+      }
+    },
+    "gitconfiglocal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
+      "integrity": "sha512-spLUXeTAVHxDtKsJc8FkFVgFtMdEN9qPGpL23VfSHx4fP4+Ds097IXLvymbnDH8FnmxX5Nr9bPw3A+AQ6mWEaQ==",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.2"
       }
     },
     "github-slugger": {

--- a/package.json
+++ b/package.json
@@ -16,28 +16,135 @@
       "main"
     ],
     "plugins": [
-      "@semantic-release/commit-analyzer",
-      ["@semantic-release/release-notes-generator", {
-        "preset": "conventionalcommits",
-        "parserOpts": {
-          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
-        },
-        "presetConfig": {
-          "types": [
-            {"type": "add", "section": "Added"},
-            {"type": "fix", "section": "Fixed"},
-            {"type": "change", "section": "Changed"},
-            {"type": "deprecate", "section": "Deprecated"},
-            {"type": "remove", "section": "Removed"},
-            {"type": "security", "section": "Security"},
-            {"type": "chore", "hidden": true},
-            {"type": "docs", "hidden": true},
-            {"type": "style", "hidden": true},
-            {"type": "refactor", "hidden": true},
-            {"type": "perf", "hidden": true},
-            {"type": "test", "hidden": true}
-        ]}
-      }],
+      [
+        "@semantic-release/commit-analyzer",
+        {
+          "preset": "conventionalcommits",
+          "releaseRules": [
+            {
+              "type": "add",
+              "release": "minor"
+            },
+            {
+              "type": "fix",
+              "release": "patch"
+            },
+            {
+              "type": "change",
+              "release": "minor"
+            },
+            {
+              "type": "deprecate",
+              "release": "false"
+            },
+            {
+              "type": "remove",
+              "release": "minor"
+            },
+            {
+              "type": "security",
+              "release": "patch"
+            },
+            {
+              "type": "chore",
+              "release": "patch"
+            },
+            {
+              "type": "docs",
+              "scope": "README",
+              "release": false
+            },
+            {
+              "type": "refactor",
+              "release": "patch"
+            },
+            {
+              "type": "style",
+              "release": "patch"
+            },
+            {
+              "type": "perf",
+              "release": "patch"
+            },
+            {
+              "type": "test",
+              "release": false
+            }
+          ],
+          "parserOpts": {
+            "noteKeywords": [
+              "BREAKING CHANGE",
+              "BREAKING CHANGES",
+              "BREAKING"
+            ]
+          }
+        }
+      ],
+      [
+        "@semantic-release/release-notes-generator",
+        {
+          "preset": "conventionalcommits",
+          "parserOpts": {
+            "noteKeywords": [
+              "BREAKING CHANGE",
+              "BREAKING CHANGES",
+              "BREAKING"
+            ]
+          },
+          "presetConfig": {
+            "types": [
+              {
+                "type": "add",
+                "section": "Added"
+              },
+              {
+                "type": "fix",
+                "section": "Fixed"
+              },
+              {
+                "type": "change",
+                "section": "Changed"
+              },
+              {
+                "type": "deprecate",
+                "section": "Deprecated"
+              },
+              {
+                "type": "remove",
+                "section": "Removed"
+              },
+              {
+                "type": "security",
+                "section": "Security"
+              },
+              {
+                "type": "chore",
+                "hidden": true
+              },
+              {
+                "type": "docs",
+                "hidden": "Changed"
+              },
+              {
+                "type": "style",
+                "hidden": "Changed"
+              },
+              {
+                "type": "refactor",
+                "hidden": "Changed"
+              },
+              {
+                "type": "perf",
+                "hidden": "Changed"
+              },
+              {
+                "type": "test",
+                "hidden": "Changed"
+              }
+            ]
+          }
+        }
+      ],
       "@semantic-release/changelog",
       "@semantic-release/npm",
       "@semantic-release/git",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,12 @@
         },
         "presetConfig": {
           "types": [
-            {"type": "feat", "section": "Added"},
+            {"type": "add", "section": "Added"},
             {"type": "fix", "section": "Fixed"},
+            {"type": "change", "section": "Changed"},
+            {"type": "deprecate", "section": "Deprecated"},
+            {"type": "remove", "section": "Removed"},
+            {"type": "security", "section": "Security"},
             {"type": "chore", "hidden": true},
             {"type": "docs", "hidden": true},
             {"type": "style", "hidden": true},

--- a/package.json
+++ b/package.json
@@ -17,7 +17,23 @@
     ],
     "plugins": [
       "@semantic-release/commit-analyzer",
-      "@semantic-release/release-notes-generator",
+      ["@semantic-release/release-notes-generator", {
+        "preset": "conventionalcommits",
+        "parserOpts": {
+          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
+        },
+        "presetConfig": {
+          "types": [
+            {"type": "feat", "section": "Added"},
+            {"type": "fix", "section": "Fixed"},
+            {"type": "chore", "hidden": true},
+            {"type": "docs", "hidden": true},
+            {"type": "style", "hidden": true},
+            {"type": "refactor", "hidden": true},
+            {"type": "perf", "hidden": true},
+            {"type": "test", "hidden": true}
+        ]}
+      }],
       "@semantic-release/changelog",
       "@semantic-release/npm",
       "@semantic-release/git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silintl/ui-components",
-  "version": "3.2.0",
+  "version": "10.0.1",
   "description": "Reusable Svelte components for some internal applications",
   "main": "index.mjs",
   "module": "index.mjs",
@@ -9,147 +9,8 @@
     "test": "echo test",
     "format-all": "npx prettier --write .",
     "dev": "sass components/global.scss components/global.css; start-storybook -p 6007",
-    "build": "sass components/global.scss components/global.css; build-storybook"
-  },
-  "release": {
-    "branches": [
-      "main"
-    ],
-    "plugins": [
-      [
-        "@semantic-release/commit-analyzer",
-        {
-          "preset": "conventionalcommits",
-          "releaseRules": [
-            {
-              "type": "add",
-              "release": "minor"
-            },
-            {
-              "type": "fix",
-              "release": "patch"
-            },
-            {
-              "type": "change",
-              "release": "minor"
-            },
-            {
-              "type": "deprecate",
-              "release": "false"
-            },
-            {
-              "type": "remove",
-              "release": "minor"
-            },
-            {
-              "type": "security",
-              "release": "patch"
-            },
-            {
-              "type": "chore",
-              "release": "patch"
-            },
-            {
-              "type": "docs",
-              "scope": "README",
-              "release": false
-            },
-            {
-              "type": "refactor",
-              "release": "patch"
-            },
-            {
-              "type": "style",
-              "release": "patch"
-            },
-            {
-              "type": "perf",
-              "release": "patch"
-            },
-            {
-              "type": "test",
-              "release": false
-            }
-          ],
-          "parserOpts": {
-            "noteKeywords": [
-              "BREAKING CHANGE",
-              "BREAKING CHANGES",
-              "BREAKING"
-            ]
-          }
-        }
-      ],
-      [
-        "@semantic-release/release-notes-generator",
-        {
-          "preset": "conventionalcommits",
-          "parserOpts": {
-            "noteKeywords": [
-              "BREAKING CHANGE",
-              "BREAKING CHANGES",
-              "BREAKING"
-            ]
-          },
-          "presetConfig": {
-            "types": [
-              {
-                "type": "add",
-                "section": "Added"
-              },
-              {
-                "type": "fix",
-                "section": "Fixed"
-              },
-              {
-                "type": "change",
-                "section": "Changed"
-              },
-              {
-                "type": "deprecate",
-                "section": "Deprecated"
-              },
-              {
-                "type": "remove",
-                "section": "Removed"
-              },
-              {
-                "type": "security",
-                "section": "Security"
-              },
-              {
-                "type": "chore",
-                "hidden": true
-              },
-              {
-                "type": "docs",
-                "hidden": "Changed"
-              },
-              {
-                "type": "style",
-                "hidden": "Changed"
-              },
-              {
-                "type": "refactor",
-                "hidden": "Changed"
-              },
-              {
-                "type": "perf",
-                "hidden": "Changed"
-              },
-              {
-                "type": "test",
-                "hidden": "Changed"
-              }
-            ]
-          }
-        }
-      ],
-      "@semantic-release/changelog",
-      "@semantic-release/npm",
-      "@semantic-release/git",
-      "@semantic-release/github"
-    ]
+    "build": "sass components/global.scss components/global.css; build-storybook",
+    "dry": "npx semantic-release --dry-run"
   },
   "repository": {
     "type": "git",
@@ -170,8 +31,8 @@
   "homepage": "https://github.com/silinternational/ui-components#readme",
   "peerDependencies": {
     "material-components-web": "^14.0.0",
-    "svelte": "^3.x",
-    "sass": "1.55.x"
+    "sass": "1.55.x",
+    "svelte": "^3.x"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.2",
@@ -186,6 +47,7 @@
     "@storybook/manager-webpack5": "^6.5.16",
     "@storybook/preset-scss": "^1.0.3",
     "@storybook/svelte": "^6.5.16",
+    "conventional-changelog": "^3.1.25",
     "css-loader": "^6.7.3",
     "material-components-web": "^14.0.0",
     "prettier": "^2.8.5",

--- a/release.config.js
+++ b/release.config.js
@@ -146,6 +146,7 @@ function getCIConfig() {
   // contains your normal semantic-release config
   // this will be used on your CI environment
   return {
+    branches: ['main'],
     plugins: [
       ...plugins,
       '@semantic-release/changelog',

--- a/release.config.js
+++ b/release.config.js
@@ -20,7 +20,7 @@ const plugins = [
         },
         {
           type: 'change',
-          release: 'patch',
+          release: 'minor',
         },
         {
           type: 'deprecate',

--- a/release.config.js
+++ b/release.config.js
@@ -11,12 +11,16 @@ const plugins = [
           release: 'minor',
         },
         {
+          type: 'feat',
+          release: 'minor',
+        },
+        {
           type: 'fix',
           release: 'patch',
         },
         {
           type: 'change',
-          release: 'minor',
+          release: 'patch',
         },
         {
           type: 'deprecate',
@@ -72,6 +76,10 @@ const plugins = [
         types: [
           {
             type: 'add',
+            section: 'Added',
+          },
+          {
+            type: 'feat',
             section: 'Added',
           },
           {

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,174 @@
+const { execSync } = require('child_process');
+
+const plugins = [
+  [
+    "@semantic-release/commit-analyzer",
+    {
+      "preset": "conventionalcommits",
+      "releaseRules": [
+        {
+          "type": "add",
+          "release": "minor"
+        },
+        {
+          "type": "fix",
+          "release": "patch"
+        },
+        {
+          "type": "change",
+          "release": "minor"
+        },
+        {
+          "type": "deprecate",
+          "release": "minor"
+        },
+        {
+          "type": "remove",
+          "release": "minor"
+        },
+        {
+          "type": "security",
+          "release": "patch"
+        },
+        {
+          "type": "chore",
+          "release": "patch"
+        },
+        {
+          "type": "docs",
+          "scope": "README",
+          "release": "patch"
+        },
+        {
+          "type": "refactor",
+          "release": "patch"
+        },
+        {
+          "type": "style",
+          "release": "patch"
+        },
+        {
+          "type": "perf",
+          "release": "patch"
+        },
+        {
+          "type": "test",
+          "release": "patch"
+        }
+      ],
+      "parserOpts": {
+        "noteKeywords": [
+          "BREAKING CHANGE",
+          "BREAKING CHANGES",
+          "BREAKING"
+        ]
+      }
+    }
+  ],
+  [
+    "@semantic-release/release-notes-generator",
+    {
+      "preset": "conventionalcommits",
+      "parserOpts": {
+        "noteKeywords": [
+          "BREAKING CHANGE",
+          "BREAKING CHANGES",
+          "BREAKING"
+        ]
+      },
+      "presetConfig": {
+        "types": [
+          {
+            "type": "add",
+            "section": "Added"
+          },
+          {
+            "type": "fix",
+            "section": "Fixed"
+          },
+          {
+            "type": "change",
+            "section": "Changed"
+          },
+          {
+            "type": "deprecate",
+            "section": "Deprecated"
+          },
+          {
+            "type": "remove",
+            "section": "Removed"
+          },
+          {
+            "type": "security",
+            "section": "Security"
+          },
+          {
+            "type": "chore",
+            "hidden": true
+          },
+          {
+            "type": "docs",
+            "section": "Changed"
+          },
+          {
+            "type": "style",
+            "section": "Changed"
+          },
+          {
+            "type": "refactor",
+            "section": "Changed"
+          },
+          {
+            "type": "perf",
+            "section": "Changed"
+          },
+          {
+            "type": "test",
+            "section": "Changed"
+          }
+        ]
+      }
+    }
+  ],
+]
+
+module.exports = isDryRun() ? getDryRunConfig() : getCIConfig();
+
+function getDryRunConfig() {
+  return {
+    repositoryUrl: getLocalRepoUrl(),
+    branches: getCurrentBranch(),
+    plugins: plugins
+  };
+}
+
+function getCIConfig() {
+  // contains your normal semantic-release config
+  // this will be used on your CI environment
+  return {
+    plugins: [
+    ...plugins,
+    "@semantic-release/changelog",
+    "@semantic-release/npm",
+    "@semantic-release/git",
+    "@semantic-release/github"]
+  };
+}
+
+function isDryRun() {
+  return process.argv.includes('--dry-run');
+}
+
+function getLocalRepoUrl() {
+  const topLevelDir = execSync('git rev-parse --show-toplevel')
+    .toString()
+    .trim();
+
+  return `file://${topLevelDir}/.git`;
+}
+
+function getCurrentBranch() {
+  return execSync('git rev-parse --abbrev-ref HEAD')
+    .toString()
+    .trim();
+}

--- a/release.config.js
+++ b/release.config.js
@@ -1,145 +1,137 @@
-const { execSync } = require('child_process');
+const { execSync } = require('child_process')
 
 const plugins = [
   [
-    "@semantic-release/commit-analyzer",
+    '@semantic-release/commit-analyzer',
     {
-      "preset": "conventionalcommits",
-      "releaseRules": [
+      preset: 'conventionalcommits',
+      releaseRules: [
         {
-          "type": "add",
-          "release": "minor"
+          type: 'add',
+          release: 'minor',
         },
         {
-          "type": "fix",
-          "release": "patch"
+          type: 'fix',
+          release: 'patch',
         },
         {
-          "type": "change",
-          "release": "minor"
+          type: 'change',
+          release: 'minor',
         },
         {
-          "type": "deprecate",
-          "release": "minor"
+          type: 'deprecate',
+          release: 'minor',
         },
         {
-          "type": "remove",
-          "release": "minor"
+          type: 'remove',
+          release: 'minor',
         },
         {
-          "type": "security",
-          "release": "patch"
+          type: 'security',
+          release: 'patch',
         },
         {
-          "type": "chore",
-          "release": "patch"
+          type: 'chore',
+          release: 'patch',
         },
         {
-          "type": "docs",
-          "scope": "README",
-          "release": "patch"
+          type: 'docs',
+          scope: 'README',
+          release: 'patch',
         },
         {
-          "type": "refactor",
-          "release": "patch"
+          type: 'refactor',
+          release: 'patch',
         },
         {
-          "type": "style",
-          "release": "patch"
+          type: 'style',
+          release: 'patch',
         },
         {
-          "type": "perf",
-          "release": "patch"
+          type: 'perf',
+          release: 'patch',
         },
         {
-          "type": "test",
-          "release": "patch"
-        }
+          type: 'test',
+          release: 'patch',
+        },
       ],
-      "parserOpts": {
-        "noteKeywords": [
-          "BREAKING CHANGE",
-          "BREAKING CHANGES",
-          "BREAKING"
-        ]
-      }
-    }
+      parserOpts: {
+        noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES', 'BREAKING'],
+      },
+    },
   ],
   [
-    "@semantic-release/release-notes-generator",
+    '@semantic-release/release-notes-generator',
     {
-      "preset": "conventionalcommits",
-      "parserOpts": {
-        "noteKeywords": [
-          "BREAKING CHANGE",
-          "BREAKING CHANGES",
-          "BREAKING"
-        ]
+      preset: 'conventionalcommits',
+      parserOpts: {
+        noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES', 'BREAKING'],
       },
-      "presetConfig": {
-        "types": [
+      presetConfig: {
+        types: [
           {
-            "type": "add",
-            "section": "Added"
+            type: 'add',
+            section: 'Added',
           },
           {
-            "type": "fix",
-            "section": "Fixed"
+            type: 'fix',
+            section: 'Fixed',
           },
           {
-            "type": "change",
-            "section": "Changed"
+            type: 'change',
+            section: 'Changed',
           },
           {
-            "type": "deprecate",
-            "section": "Deprecated"
+            type: 'deprecate',
+            section: 'Deprecated',
           },
           {
-            "type": "remove",
-            "section": "Removed"
+            type: 'remove',
+            section: 'Removed',
           },
           {
-            "type": "security",
-            "section": "Security"
+            type: 'security',
+            section: 'Security',
           },
           {
-            "type": "chore",
-            "hidden": true
+            type: 'chore',
+            hidden: true,
           },
           {
-            "type": "docs",
-            "section": "Changed"
+            type: 'docs',
+            section: 'Changed',
           },
           {
-            "type": "style",
-            "section": "Changed"
+            type: 'style',
+            section: 'Changed',
           },
           {
-            "type": "refactor",
-            "section": "Changed"
+            type: 'refactor',
+            section: 'Changed',
           },
           {
-            "type": "perf",
-            "section": "Changed"
+            type: 'perf',
+            section: 'Changed',
           },
           {
-            "type": "test",
-            "section": "Changed"
-          }
-        ]
-      }
-    }
+            type: 'test',
+            section: 'Changed',
+          },
+        ],
+      },
+    },
   ],
 ]
 
-module.exports = isDryRun() ? getDryRunConfig() : getCIConfig();
+module.exports = isDryRun() ? getDryRunConfig() : getCIConfig()
 
 function getDryRunConfig() {
   return {
     repositoryUrl: getLocalRepoUrl(),
     branches: getCurrentBranch(),
-    plugins: plugins
-  };
+    plugins: plugins,
+  }
 }
 
 function getCIConfig() {
@@ -147,28 +139,25 @@ function getCIConfig() {
   // this will be used on your CI environment
   return {
     plugins: [
-    ...plugins,
-    "@semantic-release/changelog",
-    "@semantic-release/npm",
-    "@semantic-release/git",
-    "@semantic-release/github"]
-  };
+      ...plugins,
+      '@semantic-release/changelog',
+      '@semantic-release/npm',
+      '@semantic-release/git',
+      '@semantic-release/github',
+    ],
+  }
 }
 
 function isDryRun() {
-  return process.argv.includes('--dry-run');
+  return process.argv.includes('--dry-run')
 }
 
 function getLocalRepoUrl() {
-  const topLevelDir = execSync('git rev-parse --show-toplevel')
-    .toString()
-    .trim();
+  const topLevelDir = execSync('git rev-parse --show-toplevel').toString().trim()
 
-  return `file://${topLevelDir}/.git`;
+  return `file://${topLevelDir}/.git`
 }
 
 function getCurrentBranch() {
-  return execSync('git rev-parse --abbrev-ref HEAD')
-    .toString()
-    .trim();
+  return execSync('git rev-parse --abbrev-ref HEAD').toString().trim()
 }


### PR DESCRIPTION
## Added
- Added dry command to see notes and version from semantic-release (see partial output below)
- Added release.config.js (copied from https://blog.elantha.com/semantic-release-local-dry-run/)

## Changed
- release-config: use conventionalcommits and custom release rules and notes with semantic release

Note: I had to merge main into this branch to not get all the changes since version 3.2

```[10:45:32 AM] [semantic-release] › ✔  Completed step "analyzeCommits" of plugin "@semantic-release/commit-analyzer"
[10:45:32 AM] [semantic-release] › ℹ  The next release version is 10.1.0
[10:45:32 AM] [semantic-release] › ℹ  Start step "generateNotes" of plugin "@semantic-release/release-notes-generator"
[10:45:32 AM] [semantic-release] › ✔  Completed step "generateNotes" of plugin "@semantic-release/release-notes-generator"
[10:45:32 AM] [semantic-release] › ⚠  Skip v10.1.0 tag creation in dry-run mode
[10:45:32 AM] [semantic-release] › ✔  Published release 10.1.0 on default channel
[10:45:32 AM] [semantic-release] › ℹ  Release note for version 10.1.0:
## 10.1.0 (https:/Users/mike/projects/ui-components//compare/v10.0.1...v10.1.0) (2023-03-28)

### Changed

    * release-config: use conventionalcommits and custom release rules and notes with semantic release (3537856 (https:/Users/mike/projects/ui-components//commit/3537856be3d599a89a6b054039c3965eb09b9c19))```