### PR TITLE
Feat/text field description as helper

### DIFF
--- a/components/mdc/TextInput/TextField.svelte
+++ b/components/mdc/TextInput/TextField.svelte
@@ -104,19 +104,24 @@ const focus = (node) => autofocus && node.focus()
   </span>
 </label>
 <div class="mdc-text-field-helper-line" style="width: {width};">
-  <div class="mdc-text-field-helper-text" class:opacity1={required} id="{labelID}-helper-id" aria-hidden="true">
-    {#if required && !value}
-      <span class="required" class:error={hasFocused}>*Required</span>
+  <div
+    class="mdc-text-field-helper-text
+    mdc-text-field-helper-text--{error ? 'validation-msg' : 'persistent'}"
+    id="{labelID}-helper-id"
+    aria-hidden="true"
+  >
+    {#if !error && description}
+      {description}
+    {:else if required && !value}
+      ✴Required
     {:else if hasExceededMaxLength}
-      <span class="error">Maximum {maxlength} characters</span>
+      Maximum {maxlength} characters
     {/if}
   </div>
+
   {#if showCounter}
     <div class="mdc-text-field-character-counter" class:error>
       {value.length} / {maxlength}
     </div>
   {/if}
 </div>
-{#if description}
-  <span class="d-block mdc-theme--neutral">{description}</span>
-{/if}

--- a/stories/TextField.stories.svelte
+++ b/stories/TextField.stories.svelte
@@ -8,6 +8,16 @@ const args = {
   'on:keypress': (event) => (lastKey = event.key),
   'on:keyup': (event) => console.log('TextField keyup', event),
   class: '', //will only work with global class
+  label: '',
+  value: '',
+  placeholder: '',
+  maxlength: 0,
+  autofocus: false,
+  disabled: false,
+  required: false,
+  icon: '',
+  description: '',
+  name: '',
 }
 
 let lastKey = ''


### PR DESCRIPTION
Support everything that TextFieldWithLabel adds to ui-components/TextField so we can deprecate Cover/TextFieldWithLabel

- [x] Insert {description} as Helper Text. Show it by default with  mdc-text-field-helper-text--persistent.
- [x] When a validation condition makes it appropriate to show different helper text, replace the description and apply mdc-text-field-helper-text--validation-msg.
- [x] Display a required indicator (e.g. icon or asterisk) when <input> has the :required attribute. You don't need a .required CSS class if you select on :required {}.

[CVR-646 Deprecate TextFieldWithLabel and improve TextField](https://itse.youtrack.cloud/issue/CVR-646/Deprecate-TextFieldWithLabel-and-improve-TextField)

Bonus
- [x] Add more fields to the TextField Storybook story so we can test these changes