### PR TITLE
Add description prop to checkbox and select and type prop to TextField

### DIFF
--- a/components/mdc/Checkbox/Checkbox.svelte
+++ b/components/mdc/Checkbox/Checkbox.svelte
@@ -9,6 +9,8 @@ const dispatch = createEventDispatcher()
 
 /** @type {string} the label text*/
 export let label = ''
+/** @type {string} the description text*/
+export let description = ''
 /** @type {boolean} if the checkbox is checked or not */
 export let checked = false
 /** @type {boolean} if the checkbox is disabled or not */
@@ -46,4 +48,16 @@ const handleChange = () => dispatch(checkbox.checked ? 'checked' : 'unchecked')
     <div class="mdc-checkbox__ripple" />
   </div>
   <label class:uppercase for={inputID}>{label}</label>
+</div>
+<div class="mdc-text-field-helper-line" style="margin-left: 10px">
+  <div
+    class="mdc-text-field-helper-text
+    mdc-text-field-helper-text--persistent"
+    id="{inputID}-helper-id"
+    aria-hidden="true"
+  >
+    {#if description}
+      {description}
+    {/if}
+  </div>
 </div>

--- a/components/mdc/Checkbox/Checkbox.svelte
+++ b/components/mdc/Checkbox/Checkbox.svelte
@@ -49,7 +49,7 @@ const handleChange = () => dispatch(checkbox.checked ? 'checked' : 'unchecked')
   </div>
   <label class:uppercase for={inputID}>{label}</label>
 </div>
-<div class="mdc-text-field-helper-line" style="margin-left: 10px">
+<div class="mdc-text-field-helper-line ml-10px">
   <div
     class="mdc-text-field-helper-text
     mdc-text-field-helper-text--persistent"

--- a/components/mdc/Select/Select.svelte
+++ b/components/mdc/Select/Select.svelte
@@ -7,6 +7,9 @@ import { afterUpdate, createEventDispatcher, onMount } from 'svelte'
 /** @type displayed with the mdc-floating-label class */
 export let label = 'Select'
 
+/** @type {string} The description to display below the select list. */
+export let description = ''
+
 /** @type {{id: string, name: string}[]} The options to be displayed in the select list. */
 export let options = []
 /** @type {string} The width of the select list. E.g. '280px' */
@@ -112,5 +115,17 @@ afterUpdate(() => {
         </li>
       {/each}
     </ul>
+  </div>
+</div>
+<div class="mdc-text-field-helper-line">
+  <div
+    class="mdc-text-field-helper-text
+    mdc-text-field-helper-text--persistent"
+    id="{labelID}-helper-id"
+    aria-hidden="true"
+  >
+    {#if description}
+      {description}
+    {/if}
   </div>
 </div>

--- a/components/mdc/TextInput/TextField.svelte
+++ b/components/mdc/TextInput/TextField.svelte
@@ -29,6 +29,8 @@ export let name = ''
 export let showError = false
 /** @type {boolean} lets the component know to use warn class. */
 export let showWarn = false
+/** @type {string} The type of the text input field. */
+export let type = 'text'
 
 const labelID = generateRandomID('text-label-')
 
@@ -84,7 +86,6 @@ const focus = (node) => autofocus && node.focus()
     >
   {/if}
   <input
-    type="text"
     class="mdc-text-field__input"
     aria-labelledby={labelID}
     aria-controls="{labelID}-helper-id"
@@ -101,6 +102,7 @@ const focus = (node) => autofocus && node.focus()
     {name}
     {required}
     {disabled}
+    {...{ type }}
     maxlength="524288"
     {placeholder}
   />

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,6 +32,7 @@ declare module '@silintl/ui-components' {
 
   interface CheckboxProps {
     label?: string
+    description: string
     checked?: boolean
     disabled?: boolean
     uppercase?: boolean
@@ -235,6 +236,7 @@ declare module '@silintl/ui-components' {
   interface SelectProps {
     disabled?: boolean
     label?: string
+    description?: string
     name?: string
     options?: { name: string; id: string }[]
     required?: boolean
@@ -298,6 +300,7 @@ declare module '@silintl/ui-components' {
     value?: string
     name?: string
     icon?: string
+    type?: string
     placeholder?: string
     maxlength?: number
     autofocus?: boolean

--- a/stories/Checkbox.stories.svelte
+++ b/stories/Checkbox.stories.svelte
@@ -6,6 +6,7 @@ import { copyAndModifyArgs } from './helpers.js'
 const args = {
   label: 'Checkbox',
   class: '', //only works for global classes
+  description: '',
   'on:checked': () => setNotice('checked'),
   'on:unchecked': () => setNotice('unchecked'),
 }

--- a/stories/Select.stories.svelte
+++ b/stories/Select.stories.svelte
@@ -13,6 +13,7 @@ const args = {
     { name: 'choice 5', id: '4' },
     { name: 'choice 6', id: '5' },
   ],
+  description: '',
   'on:change': (e) => console.log('option: ', e.detail, 'const onChange = (e) => selectedOption = e.detail'),
   'on:populated': () => console.log('it is safe to set selectedID'),
   class: '', //only works for global classes

--- a/stories/TextField.stories.svelte
+++ b/stories/TextField.stories.svelte
@@ -18,6 +18,7 @@ const args = {
   icon: '',
   description: '',
   name: '',
+  type: 'text',
 }
 
 let lastKey = ''
@@ -51,6 +52,8 @@ let lastKey = ''
 <Story name="Description" args={copyAndModifyArgs(args, { description: 'a description' })} />
 
 <Story name="Name" args={copyAndModifyArgs(args, { name: 'field' })} />
+
+<Story name="Type" args={copyAndModifyArgs(args, { type: 'text' })} />
 
 <Story name="showError" args={copyAndModifyArgs(args, { showError: true })} />
 


### PR DESCRIPTION
## Checkbox Component
- Added `description` prop.
- Rendered description text as helper text below the checkbox.

## Select Component
- Added `description` prop.
- Rendered description text as persistent helper text.

## TextField Component
- Added `type` prop to allow for more flexible input field types, such as 'email'

## Type Definitions
- Updated `index.d.ts` to include the new props for each component.

## Storybook Updates
- Enhanced stories for `Checkbox`, `Select`, and `TextField` to demonstrate the new `description` and 'type' prop.


### Feature branch checklist

- [ ] Documentation (README, etc.)
- [ ] Run `make format`, `make dry` and `make install`
